### PR TITLE
refactor: use nanoid for measurement ids

### DIFF
--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { nanoid } from 'nanoid/non-secure';
 
 export interface GlucoseMeasurement {
   id: string;
@@ -9,6 +10,8 @@ export interface GlucoseMeasurement {
 }
 
 const STORAGE_KEY = 'glucose_measurements';
+
+export const generateMeasurementId = (): string => nanoid();
 
 export const getStoredMeasurements = async (): Promise<GlucoseMeasurement[]> => {
   try {
@@ -30,9 +33,9 @@ export const addMeasurement = async (measurement: Omit<GlucoseMeasurement, 'id'>
     const measurements = await getStoredMeasurements();
     const newMeasurement: GlucoseMeasurement = {
       ...measurement,
-      id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
+      id: generateMeasurementId(),
     };
-    
+
     measurements.unshift(newMeasurement);
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(measurements));
     return newMeasurement;

--- a/utils/storageManager.ts
+++ b/utils/storageManager.ts
@@ -6,7 +6,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { auth } from '@/config/firebase';
 import { SecureHybridStorage, EncryptionService } from './secureCloudStorage';
-import { GlucoseMeasurement } from './storage';
+import { GlucoseMeasurement, generateMeasurementId } from './storage';
 
 // Configuration du stockage (utilise les mêmes clés que SecureHybridStorage)
 const STORAGE_CONFIG = {
@@ -75,7 +75,7 @@ export class StorageManager {
       // Fallback : stockage local uniquement
       const newMeasurement: GlucoseMeasurement = {
         ...measurement,
-        id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
+        id: generateMeasurementId(),
       };
 
       await this.saveToLocal(newMeasurement);


### PR DESCRIPTION
## Summary
- replace manual ID generation with `nanoid`
- centralize measurement ID creation via `generateMeasurementId`

## Testing
- `npm test`
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c6e28df8c83329a366790db2ed9cd