### PR TITLE
Use global crypto with expo-random fallback

### DIFF
--- a/utils/simpleCrypto.ts
+++ b/utils/simpleCrypto.ts
@@ -9,11 +9,16 @@ export class SimpleCrypto {
    * Génère des octets aléatoires en utilisant un générateur cryptographiquement sûr
    */
   private static getSecureBytes(length: number): Uint8Array {
+    if (globalThis.crypto?.getRandomValues) {
+      const array = new Uint8Array(length);
+      globalThis.crypto.getRandomValues(array);
+      return array;
+    }
     try {
-      const { getRandomBytes } = eval('require')( 'expo-random');
+      const { getRandomBytes } = require('expo-random');
       return getRandomBytes(length);
     } catch {
-      const { randomBytes } = eval('require')('crypto');
+      const { randomBytes } = require('crypto');
       return new Uint8Array(randomBytes(length));
     }
   }


### PR DESCRIPTION
## Summary
- generate secure bytes with globalThis.crypto when possible
- fallback to expo-random or Node's crypto without using eval

## Testing
- `npm test`
- `node -e "require('ts-node/register'); const { EncryptionService } = require('./utils/secureCloudStorage'); EncryptionService.initializeEncryptionKey().then(()=>console.log('done')).catch(err=>console.error('error',err));"` *(fails: SyntaxError: Unexpected token 'typeof')*

------
https://chatgpt.com/codex/tasks/task_e_689c98f958d483329f4ce51729dcb523