### PR TITLE
refactor: use expo random for secure bytes

### DIFF
--- a/utils/simpleCrypto.ts
+++ b/utils/simpleCrypto.ts
@@ -1,4 +1,5 @@
 import CryptoJS from 'crypto-js';
+import { getRandomBytes } from 'expo-random';
 
 /**
  * Service de chiffrement compatible avec React Native - VERSION SANS MODULE CRYPTO NATIF
@@ -14,13 +15,7 @@ export class SimpleCrypto {
       globalThis.crypto.getRandomValues(array);
       return array;
     }
-    try {
-      const { getRandomBytes } = require('expo-random');
-      return getRandomBytes(length);
-    } catch {
-      const { randomBytes } = require('crypto');
-      return new Uint8Array(randomBytes(length));
-    }
+    return getRandomBytes(length);
   }
 
   /**


### PR DESCRIPTION
## Summary
- use expo-random to supply secure bytes for SimpleCrypto
- drop Node `crypto` fallback to avoid bundler warnings

## Testing
- `npm test` *(fails: TypeError: Unknown file extension ".ts" for expo-modules-core)*
- `npm run dev -- --offline`

------
https://chatgpt.com/codex/tasks/task_e_689cb1c407c88332ac1db7f680c2b60f