### PR TITLE
feat: add theme provider and palette

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,10 +13,13 @@ import PredictiveAnalysis from '@/components/PredictiveAnalysis';
 import ComparisonAnalysis from '@/components/ComparisonAnalysis';
 import PDFExport from '@/components/PDFExport';
 import StatsCards from '@/components/StatsCards';
+import { useTheme } from '@/theme';
 
 function HomeScreen() {
   const { t } = useTranslation();
   const { userSettings } = useSettings();
+  const { colors, gradients } = useTheme();
+  const styles = createStyles(colors);
   const [measurements, setMeasurements] = useState<GlucoseMeasurement[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -81,18 +84,18 @@ function HomeScreen() {
     if (!latestMeasurement || !previousMeasurement) return null;
     
     const diff = latestMeasurement.value - previousMeasurement.value;
-    if (diff > 0) return <TrendingUp size={20} color="#FF6B35" />;
-    if (diff < 0) return <TrendingDown size={20} color="#00D9FF" />;
-    return <Activity size={20} color="#8B5CF6" />;
+    if (diff > 0) return <TrendingUp size={20} color={colors.warning} />;
+    if (diff < 0) return <TrendingDown size={20} color={colors.secondary} />;
+    return <Activity size={20} color={colors.accent} />;
   };
 
   const getStatusColor = (value: number) => {
     const status = getGlucoseStatus(value);
     switch (status) {
-      case 'low': return '#FF3B82';
-      case 'high': return '#FF6B35';
-      case 'normal': return '#00D9FF';
-      default: return '#8B5CF6';
+      case 'low': return colors.danger;
+      case 'high': return colors.warning;
+      case 'normal': return colors.secondary;
+      default: return colors.accent;
     }
   };
 
@@ -109,11 +112,11 @@ function HomeScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <LinearGradient
-        colors={['#667EEA', '#764BA2', '#F093FB']}
+        colors={gradients.primary}
         style={styles.gradient}
       >
-        <ScrollView 
-          style={styles.scrollView} 
+        <ScrollView
+          style={styles.scrollView}
           showsVerticalScrollIndicator={false}
           refreshControl={
             <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
@@ -121,7 +124,7 @@ function HomeScreen() {
         >
           <View style={styles.header}>
             <View style={styles.headerIcon}>
-              <Sparkles size={32} color="#FFFFFF" />
+              <Sparkles size={32} color={colors.white} />
             </View>
             <Text style={styles.title}>{t('home.title')}</Text>
             <Text style={styles.subtitle}>{t('home.subtitle')}</Text>
@@ -134,7 +137,7 @@ function HomeScreen() {
                 {getTrendIcon()}
               </View>
               <View style={styles.currentValueContainer}>
-                <Text style={[styles.currentValue, { color: getStatusColor(latestMeasurement.value) }]}>
+                <Text style={[styles.currentValue, { color: getStatusColor(latestMeasurement.value) }]}> 
                   {latestMeasurement.value}
                 </Text>
                 <Text style={styles.currentUnit}>{unitLabel}</Text>
@@ -149,10 +152,10 @@ function HomeScreen() {
           ) : (
             <View style={styles.emptyCard}>
               <LinearGradient
-                colors={['#FF9A9E', '#FECFEF']}
+                colors={gradients.empty}
                 style={styles.emptyIconContainer}
               >
-                <AlertTriangle size={48} color="#FFFFFF" />
+                <AlertTriangle size={48} color={colors.white} />
               </LinearGradient>
               <Text style={styles.emptyTitle}>{t('home.noMeasurements')}</Text>
               <Text style={styles.emptySubtitle}>
@@ -170,7 +173,7 @@ function HomeScreen() {
           <View style={styles.chartSection}>
             <View style={styles.chartHeader}>
               <View style={styles.chartTitleContainer}>
-                <BarChart3 size={20} color="#FFFFFF" />
+                <BarChart3 size={20} color={colors.white} />
                 <Text style={styles.chartTitle}>{t('home.chart')}</Text>
               </View>
               <View style={styles.periodSelector}>
@@ -207,7 +210,7 @@ function HomeScreen() {
             {measurements.slice(0, 5).map((measurement, index) => (
               <View key={measurement.id} style={styles.recentItem}>
                 <View style={styles.recentLeft}>
-                  <Text style={[styles.recentValue, { color: getStatusColor(measurement.value) }]}>
+                  <Text style={[styles.recentValue, { color: getStatusColor(measurement.value) }]}> 
                     {measurement.value} mg/dL
                   </Text>
                   <Text style={styles.recentType}>{measurement.type}</Text>
@@ -227,206 +230,207 @@ function HomeScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#667EEA',
-  },
-  gradient: {
-    flex: 1,
-  },
-  scrollView: {
-    flex: 1,
-    paddingHorizontal: 16,
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  loadingText: {
-    fontSize: 18,
-    color: '#6B7280',
-  },
-  header: {
-    paddingTop: 16,
-    paddingBottom: 24,
-    alignItems: 'center',
-  },
-  headerIcon: {
-    marginBottom: 12,
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: '#FFFFFF',
-    marginBottom: 4,
-    textAlign: 'center',
-  },
-  subtitle: {
-    fontSize: 16,
-    color: '#E0E7FF',
-    textAlign: 'center',
-  },
-  currentCard: {
-    backgroundColor: 'rgba(255, 255, 255, 0.95)',
-    borderRadius: 16,
-    padding: 24,
-    marginBottom: 24,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  currentHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
-  currentLabel: {
-    fontSize: 14,
-    color: '#6B7280',
-    fontWeight: '500',
-  },
-  currentValueContainer: {
-    flexDirection: 'row',
-    alignItems: 'baseline',
-    marginBottom: 8,
-  },
-  currentValue: {
-    fontSize: 48,
-    fontWeight: 'bold',
-    marginRight: 8,
-  },
-  currentUnit: {
-    fontSize: 18,
-    color: '#6B7280',
-  },
-  currentTime: {
-    fontSize: 14,
-    color: '#6B7280',
-    marginBottom: 4,
-  },
-  currentType: {
-    fontSize: 14,
-    color: '#2563EB',
-    fontWeight: '500',
-  },
-  emptyCard: {
-    backgroundColor: 'rgba(255, 255, 255, 0.95)',
-    borderRadius: 16,
-    padding: 32,
-    alignItems: 'center',
-    marginBottom: 24,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  emptyIconContainer: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 16,
-  },
-  emptyTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#2D3748',
-    marginBottom: 8,
-  },
-  emptySubtitle: {
-    fontSize: 14,
-    color: '#718096',
-    textAlign: 'center',
-  },
-  chartSection: {
-    marginBottom: 16,
-  },
-  chartHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 8,
-  },
-  chartTitleContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  chartTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#FFFFFF',
-    marginLeft: 8,
-  },
-  periodSelector: {
-    flexDirection: 'row',
-    backgroundColor: 'rgba(255, 255, 255, 0.2)',
-    borderRadius: 8,
-    padding: 2,
-  },
-  periodButton: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 6,
-  },
-  periodButtonActive: {
-    backgroundColor: 'rgba(255, 255, 255, 0.9)',
-  },
-  periodText: {
-    fontSize: 12,
-    color: '#FFFFFF',
-    fontWeight: '500',
-  },
-  periodTextActive: {
-    color: '#667EEA',
-  },
-  recentContainer: {
-    backgroundColor: 'rgba(255, 255, 255, 0.95)',
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 24,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  recentTitle: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#2D3748',
-    marginBottom: 16,
-  },
-  recentItem: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#E2E8F0',
-  },
-  recentLeft: {
-    flex: 1,
-  },
-  recentValue: {
-    fontSize: 16,
-    fontWeight: '600',
-    marginBottom: 2,
-  },
-  recentType: {
-    fontSize: 12,
-    color: '#718096',
-  },
-  recentTime: {
-    fontSize: 14,
-    color: '#718096',
-  },
-});
+const createStyles = (colors: any) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.primary,
+    },
+    gradient: {
+      flex: 1,
+    },
+    scrollView: {
+      flex: 1,
+      paddingHorizontal: 16,
+    },
+    loadingContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    loadingText: {
+      fontSize: 18,
+      color: colors.muted,
+    },
+    header: {
+      paddingTop: 16,
+      paddingBottom: 24,
+      alignItems: 'center',
+    },
+    headerIcon: {
+      marginBottom: 12,
+    },
+    title: {
+      fontSize: 28,
+      fontWeight: 'bold',
+      color: colors.white,
+      marginBottom: 4,
+      textAlign: 'center',
+    },
+    subtitle: {
+      fontSize: 16,
+      color: colors.subtitle,
+      textAlign: 'center',
+    },
+    currentCard: {
+      backgroundColor: colors.card,
+      borderRadius: 16,
+      padding: 24,
+      marginBottom: 24,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 4,
+    },
+    currentHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 16,
+    },
+    currentLabel: {
+      fontSize: 14,
+      color: colors.muted,
+      fontWeight: '500',
+    },
+    currentValueContainer: {
+      flexDirection: 'row',
+      alignItems: 'baseline',
+      marginBottom: 8,
+    },
+    currentValue: {
+      fontSize: 48,
+      fontWeight: 'bold',
+      marginRight: 8,
+    },
+    currentUnit: {
+      fontSize: 18,
+      color: colors.muted,
+    },
+    currentTime: {
+      fontSize: 14,
+      color: colors.muted,
+      marginBottom: 4,
+    },
+    currentType: {
+      fontSize: 14,
+      color: colors.info,
+      fontWeight: '500',
+    },
+    emptyCard: {
+      backgroundColor: colors.card,
+      borderRadius: 16,
+      padding: 32,
+      alignItems: 'center',
+      marginBottom: 24,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 4,
+    },
+    emptyIconContainer: {
+      width: 80,
+      height: 80,
+      borderRadius: 40,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 16,
+    },
+    emptyTitle: {
+      fontSize: 18,
+      fontWeight: '600',
+      color: colors.text,
+      marginBottom: 8,
+    },
+    emptySubtitle: {
+      fontSize: 14,
+      color: colors.muted2,
+      textAlign: 'center',
+    },
+    chartSection: {
+      marginBottom: 16,
+    },
+    chartHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 8,
+    },
+    chartTitleContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    chartTitle: {
+      fontSize: 18,
+      fontWeight: '600',
+      color: colors.white,
+      marginLeft: 8,
+    },
+    periodSelector: {
+      flexDirection: 'row',
+      backgroundColor: colors.overlayLight,
+      borderRadius: 8,
+      padding: 2,
+    },
+    periodButton: {
+      paddingHorizontal: 12,
+      paddingVertical: 6,
+      borderRadius: 6,
+    },
+    periodButtonActive: {
+      backgroundColor: colors.overlayStrong,
+    },
+    periodText: {
+      fontSize: 12,
+      color: colors.white,
+      fontWeight: '500',
+    },
+    periodTextActive: {
+      color: colors.primary,
+    },
+    recentContainer: {
+      backgroundColor: colors.card,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 24,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 4,
+    },
+    recentTitle: {
+      fontSize: 18,
+      fontWeight: '600',
+      color: colors.text,
+      marginBottom: 16,
+    },
+    recentItem: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingVertical: 12,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+    },
+    recentLeft: {
+      flex: 1,
+    },
+    recentValue: {
+      fontSize: 16,
+      fontWeight: '600',
+      marginBottom: 2,
+    },
+    recentType: {
+      fontSize: 12,
+      color: colors.muted2,
+    },
+    recentTime: {
+      fontSize: 14,
+      color: colors.muted2,
+    },
+  });
 
 export default HomeScreen;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,6 +12,7 @@ import { initializeAppServices } from '@/utils/initServices';
 import { initializeCryptoPolyfills, testCryptoPolyfills } from '@/utils/cryptoInit';
 import { StorageManager } from '@/utils/storageManager';
 import '@/utils/i18n'; // Initialiser i18n
+import { ThemeProvider } from '@/theme';
 
 // Initialiser les polyfills crypto dès que possible AVANT tous les autres imports
 initializeCryptoPolyfills();
@@ -79,7 +80,9 @@ export default function RootLayout() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <AuthProvider>
         <SettingsProvider>
-          <AppContent />
+          <ThemeProvider>
+            <AppContent />
+          </ThemeProvider>
         </SettingsProvider>
       </AuthProvider>
     </GestureHandlerRootView>

--- a/components/GlucoseChart.tsx
+++ b/components/GlucoseChart.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { View, Text, StyleSheet, Dimensions } from 'react-native';
 import { LineChart } from 'react-native-chart-kit';
 import { GlucoseMeasurement } from '@/utils/storage';
-import { getGlucoseStatus } from '@/utils/glucose';
 import { useSettings } from '@/contexts/SettingsContext';
+import { useTheme } from '@/theme';
 
 interface GlucoseChartProps {
   measurements: GlucoseMeasurement[];
@@ -12,6 +12,8 @@ interface GlucoseChartProps {
 
 export default function GlucoseChart({ measurements, period }: GlucoseChartProps) {
   const { userSettings } = useSettings();
+  const { colors } = useTheme();
+  const styles = createStyles(colors);
   const screenWidth = Dimensions.get('window').width;
   const chartWidth = screenWidth - 32;
   
@@ -59,7 +61,7 @@ export default function GlucoseChart({ measurements, period }: GlucoseChartProps
       labels,
       datasets: [{
         data,
-        color: (opacity = 1) => `rgba(102, 126, 234, ${opacity})`,
+        color: (opacity = 1) => hexToRgba(colors.primary, opacity),
         strokeWidth: 3
       }]
     };
@@ -67,22 +69,22 @@ export default function GlucoseChart({ measurements, period }: GlucoseChartProps
 
   const chartConfig = {
     backgroundColor: 'transparent',
-    backgroundGradientFrom: '#ffffff',
-    backgroundGradientTo: '#ffffff',
+    backgroundGradientFrom: colors.background,
+    backgroundGradientTo: colors.background,
     decimalPlaces: 0,
-    color: (opacity = 1) => `rgba(102, 126, 234, ${opacity})`,
-    labelColor: (opacity = 1) => `rgba(107, 114, 128, ${opacity})`,
+    color: (opacity = 1) => hexToRgba(colors.primary, opacity),
+    labelColor: (opacity = 1) => hexToRgba(colors.muted, opacity),
     style: {
       borderRadius: 16,
     },
     propsForDots: {
       r: '6',
       strokeWidth: '2',
-      stroke: '#667EEA'
+      stroke: colors.primary
     },
     propsForBackgroundLines: {
       strokeDasharray: '',
-      stroke: '#E5E7EB',
+      stroke: colors.border,
       strokeWidth: 1
     }
   };
@@ -114,15 +116,15 @@ export default function GlucoseChart({ measurements, period }: GlucoseChartProps
           
           <View style={styles.legendContainer}>
             <View style={styles.legendItem}>
-              <View style={[styles.legendDot, { backgroundColor: '#FF3B82' }]} />
+              <View style={[styles.legendDot, { backgroundColor: colors.danger }]} />
               <Text style={styles.legendText}>Bas (&lt;{targetMin})</Text>
             </View>
             <View style={styles.legendItem}>
-              <View style={[styles.legendDot, { backgroundColor: '#00D9FF' }]} />
+              <View style={[styles.legendDot, { backgroundColor: colors.secondary }]} />
               <Text style={styles.legendText}>Normal ({targetMin}-{targetMax})</Text>
             </View>
             <View style={styles.legendItem}>
-              <View style={[styles.legendDot, { backgroundColor: '#FF6B35' }]} />
+              <View style={[styles.legendDot, { backgroundColor: colors.warning }]} />
               <Text style={styles.legendText}>Élevé (&gt;{targetMax})</Text>
             </View>
           </View>
@@ -138,58 +140,66 @@ export default function GlucoseChart({ measurements, period }: GlucoseChartProps
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: 'rgba(255, 255, 255, 0.95)',
-    borderRadius: 16,
-    padding: 16,
-    marginBottom: 16,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#2D3748',
-    marginBottom: 16,
-    textAlign: 'center',
-  },
-  chartContainer: {
-    alignItems: 'center',
-  },
-  chart: {
-    borderRadius: 16,
-  },
-  legendContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    marginTop: 16,
-    paddingHorizontal: 8,
-  },
-  legendItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  legendDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    marginRight: 4,
-  },
-  legendText: {
-    fontSize: 10,
-    color: '#6B7280',
-  },
-  emptyState: {
-    alignItems: 'center',
-    paddingVertical: 40,
-  },
-  emptyText: {
-    fontSize: 14,
-    color: '#9CA3AF',
-    textAlign: 'center',
-  },
-});
+const createStyles = (colors: any) =>
+  StyleSheet.create({
+    container: {
+      backgroundColor: colors.card,
+      borderRadius: 16,
+      padding: 16,
+      marginBottom: 16,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 8,
+      elevation: 4,
+    },
+    title: {
+      fontSize: 18,
+      fontWeight: '600',
+      color: colors.text,
+      marginBottom: 16,
+      textAlign: 'center',
+    },
+    chartContainer: {
+      alignItems: 'center',
+    },
+    chart: {
+      borderRadius: 16,
+    },
+    legendContainer: {
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      marginTop: 16,
+      paddingHorizontal: 8,
+    },
+    legendItem: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    legendDot: {
+      width: 8,
+      height: 8,
+      borderRadius: 4,
+      marginRight: 4,
+    },
+    legendText: {
+      fontSize: 10,
+      color: colors.muted,
+    },
+    emptyState: {
+      alignItems: 'center',
+      paddingVertical: 40,
+    },
+    emptyText: {
+      fontSize: 14,
+      color: colors.placeholder,
+      textAlign: 'center',
+    },
+  });
+
+const hexToRgba = (hex: string, alpha: number) => {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};

--- a/contexts/SettingsContext.tsx
+++ b/contexts/SettingsContext.tsx
@@ -21,6 +21,7 @@ export interface UserSettings {
   language: Language;
   unit: GlucoseUnit;
   timezone: string;
+  theme: 'light' | 'dark' | 'system';
 }
 
 export interface AccessibilitySettings {
@@ -54,6 +55,7 @@ const defaultUserSettings: UserSettings = {
   language: 'fr',
   unit: 'mgdl',
   timezone: 'Europe/Paris',
+  theme: 'system',
 };
 
 const defaultAccessibilitySettings: AccessibilitySettings = {

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+import { useColorScheme } from 'react-native';
+import { useSettings } from '@/contexts/SettingsContext';
+
+export const lightTheme = {
+  colors: {
+    background: '#FFFFFF',
+    card: 'rgba(255,255,255,0.95)',
+    text: '#2D3748',
+    muted: '#6B7280',
+    placeholder: '#9CA3AF',
+    primary: '#667EEA',
+    secondary: '#00D9FF',
+    warning: '#FF6B35',
+    danger: '#FF3B82',
+    accent: '#8B5CF6',
+    subtitle: '#E0E7FF',
+    info: '#2563EB',
+    border: '#E2E8F0',
+    white: '#FFFFFF',
+    muted2: '#718096',
+    overlayLight: 'rgba(255,255,255,0.2)',
+    overlayStrong: 'rgba(255,255,255,0.9)',
+  },
+  gradients: {
+    primary: ['#667EEA', '#764BA2', '#F093FB'],
+    empty: ['#FF9A9E', '#FECFEF'],
+  },
+};
+
+export const darkTheme = {
+  colors: {
+    background: '#1A202C',
+    card: 'rgba(45,55,72,0.95)',
+    text: '#F7FAFC',
+    muted: '#A0AEC0',
+    placeholder: '#718096',
+    primary: '#667EEA',
+    secondary: '#00D9FF',
+    warning: '#FF6B35',
+    danger: '#FF3B82',
+    accent: '#8B5CF6',
+    subtitle: '#CBD5E1',
+    info: '#63B3ED',
+    border: '#4A5568',
+    white: '#FFFFFF',
+    muted2: '#A0AEC0',
+    overlayLight: 'rgba(255,255,255,0.1)',
+    overlayStrong: 'rgba(255,255,255,0.2)',
+  },
+  gradients: {
+    primary: ['#4C51BF', '#553C9A', '#9F7AEA'],
+    empty: ['#FF9A9E', '#FECFEF'],
+  },
+};
+
+export type Theme = typeof lightTheme;
+
+const ThemeContext = createContext<Theme>(lightTheme);
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const { userSettings } = useSettings();
+  const systemScheme = useColorScheme();
+  const scheme = userSettings.theme === 'system' ? systemScheme : userSettings.theme;
+  const theme = scheme === 'dark' ? darkTheme : lightTheme;
+
+  return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => useContext(ThemeContext);
+


### PR DESCRIPTION
## Summary
- add light and dark palettes with ThemeProvider
- expose theme preference in settings
- use theme colors across chart and home screen

## Testing
- `npm test` *(fails: Unknown file extension ".ts" for expo-modules-core)*

------
https://chatgpt.com/codex/tasks/task_e_689cb98a45c8833283f6c687759e9b0b