### PR TITLE
fix: remove trailing comma from lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
-    "lint": "expo lint",
+    "lint": "expo lint"
   },
   "dependencies": {
     "@expo/config-plugins": "~10.1.1",


### PR DESCRIPTION
## Summary
- remove trailing comma from package.json lint script

## Testing
- `npm run lint` *(fails: TypeError: fetch failed)*
- `jq . package.json`
- `npx expo start` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689cc1601f68833281206ff5043a7b06