### PR TITLE
Guard diagnostic routes behind environment flag

### DIFF
--- a/app/firebase-test.tsx
+++ b/app/firebase-test.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
 import { db, auth } from '@/config/firebase';
 import { doc, setDoc, getDoc, collection, getDocs, deleteDoc, query, where } from 'firebase/firestore';
 import { useAuth } from '@/contexts/AuthContext';
@@ -16,6 +17,16 @@ export default function FirebaseTestScreen() {
   const [logs, setLogs] = useState<string[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const toast = useToast();
+  const router = useRouter();
+  const diagnosticsEnabled = useMemo(() => {
+    return __DEV__ || process.env.EXPO_PUBLIC_ENABLE_DIAGNOSTICS === 'true';
+  }, []);
+
+  useEffect(() => {
+    if (!diagnosticsEnabled) {
+      router.replace('/welcome');
+    }
+  }, [diagnosticsEnabled, router]);
   
   const addLog = (message: string) => {
     setLogs(prev => [...prev, message]);
@@ -228,6 +239,17 @@ export default function FirebaseTestScreen() {
     }
   };
   
+  if (!diagnosticsEnabled) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Accès refusé</Text>
+        <Text style={styles.accessDeniedMessage}>
+          Les tests Firebase sont désactivés pour cet environnement.
+        </Text>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Test des Permissions Firebase</Text>
@@ -283,6 +305,11 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: 'bold',
     marginBottom: 16,
+  },
+  accessDeniedMessage: {
+    fontSize: 14,
+    color: '#4b5563',
+    textAlign: 'center',
   },
   userInfo: {
     backgroundColor: '#f0f0f0',

--- a/app/storage-diagnostic.tsx
+++ b/app/storage-diagnostic.tsx
@@ -1,5 +1,50 @@
+import { useEffect, useMemo } from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
 import StorageDiagnostic from '@/components/StorageDiagnostic';
 
 export default function StorageDiagnosticScreen() {
+  const router = useRouter();
+  const diagnosticsEnabled = useMemo(() => {
+    return __DEV__ || process.env.EXPO_PUBLIC_ENABLE_DIAGNOSTICS === 'true';
+  }, []);
+
+  useEffect(() => {
+    if (!diagnosticsEnabled) {
+      router.replace('/welcome');
+    }
+  }, [diagnosticsEnabled, router]);
+
+  if (!diagnosticsEnabled) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Accès refusé</Text>
+        <Text style={styles.message}>
+          Les diagnostics de stockage sont désactivés pour cet environnement.
+        </Text>
+      </View>
+    );
+  }
+
   return <StorageDiagnostic />;
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  message: {
+    fontSize: 14,
+    color: '#4b5563',
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
### Motivation
- Restrict access to sensitive diagnostic screens (`app/storage-diagnostic.tsx` and `app/firebase-test.tsx`) so they are not exposed in production.
- Use a simple environment gate so diagnostics are available in development or when explicitly enabled via `EXPO_PUBLIC_ENABLE_DIAGNOSTICS`.
- Redirect disallowed access to `/welcome` and provide a clear "Accès refusé" message to users.

### Description
- Added a diagnostics flag check (`__DEV__ || process.env.EXPO_PUBLIC_ENABLE_DIAGNOSTICS === 'true'`) to `app/storage-diagnostic.tsx`, using `useRouter`, `useMemo`, and `useEffect` to redirect to `/welcome` and show an access denied UI when disabled.
- Added the same diagnostics guard and access denied UI to `app/firebase-test.tsx`, plus the `useRouter` import and related hooks.
- Added simple styles for the access-denied screens and did not alter existing test/cleanup logic in `firebase-test`.
- No changes were made to `ProtectedRoute` or authentication logic.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f4fa53b08332b6b3a0fdc92c32c6)