### PR TITLE
Add profile, targets and notifications settings screens and wire navigation

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -162,15 +162,15 @@ export default function SettingsScreen() {
   // Pour ces fonctions de navigation, utilisons simplement des alertes 
   // car les écrans ne sont pas implémentés dans la structure d'app actuelle
   const navigateToProfile = () => {
-    toast.show(t('settings.profile'), t('common.feature_coming_soon'));
+    router.push('/profile-settings');
   };
 
   const navigateToTargets = () => {
-    toast.show(t('settings.targets'), t('common.feature_coming_soon'));
+    router.push('/targets');
   };
 
   const navigateToNotifications = () => {
-    toast.show(t('settings.notifications'), t('common.feature_coming_soon'));
+    router.push('/notifications');
   };
   
   const navigateToSyncSettings = () => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -45,6 +45,9 @@ function AppContent() {
         <Stack.Screen name="auth" options={{ headerShown: false }} />
         <Stack.Screen name="welcome" options={{ headerShown: false }} />
         <Stack.Screen name="storage-diagnostic" options={{ headerShown: false }} />
+        <Stack.Screen name="profile-settings" options={{ headerShown: false }} />
+        <Stack.Screen name="targets" options={{ headerShown: false }} />
+        <Stack.Screen name="notifications" options={{ headerShown: false }} />
       </Stack>
       <StatusBar style="auto" />
     </ProtectedRoute>

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  Switch,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSettings } from '@/contexts/SettingsContext';
+
+export default function NotificationsScreen() {
+  const router = useRouter();
+  const { userSettings, updateUserSetting } = useSettings();
+  const [notificationsEnabled, setNotificationsEnabled] = useState(userSettings.notifications);
+  const [persistedNotifications, setPersistedNotifications] = useState<string | null>(null);
+  const [persistenceMessage, setPersistenceMessage] = useState('');
+
+  useEffect(() => {
+    setNotificationsEnabled(userSettings.notifications);
+  }, [userSettings.notifications]);
+
+  const refreshPersistence = async () => {
+    try {
+      const storedSettings = await AsyncStorage.getItem('userSettings');
+      if (!storedSettings) {
+        setPersistedNotifications(null);
+        setPersistenceMessage('Aucune donnée persistée trouvée.');
+        return;
+      }
+      const parsed = JSON.parse(storedSettings);
+      setPersistedNotifications(parsed?.notifications ? 'Activées' : 'Désactivées');
+      setPersistenceMessage('Données chargées depuis AsyncStorage.');
+    } catch (error) {
+      console.error('Erreur lors de la lecture AsyncStorage:', error);
+      setPersistenceMessage('Erreur lors de la lecture AsyncStorage.');
+    }
+  };
+
+  useEffect(() => {
+    refreshPersistence();
+  }, []);
+
+  const toggleNotifications = async (value: boolean) => {
+    setNotificationsEnabled(value);
+    await updateUserSetting('notifications', value);
+    await refreshPersistence();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <LinearGradient colors={['#667EEA', '#764BA2']} style={styles.headerGradient}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Retour</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Notifications</Text>
+        <Text style={styles.headerSubtitle}>Gérer les alertes et rappels</Text>
+      </LinearGradient>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <View style={styles.textGroup}>
+              <Text style={styles.label}>Activer les notifications</Text>
+              <Text style={styles.helperText}>
+                Recevez des rappels pour vos saisies et vos objectifs.
+              </Text>
+            </View>
+            <Switch
+              value={notificationsEnabled}
+              onValueChange={toggleNotifications}
+              trackColor={{ false: '#D1D5DB', true: '#667EEA' }}
+              thumbColor={notificationsEnabled ? '#FFFFFF' : '#F3F4F6'}
+            />
+          </View>
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.sectionTitle}>Test de persistance AsyncStorage</Text>
+          <Text style={styles.persistenceText}>{persistenceMessage}</Text>
+          <Text style={styles.persistenceDetail}>Notifications sauvegardées : {persistedNotifications ?? '—'}</Text>
+          <TouchableOpacity style={styles.secondaryButton} onPress={refreshPersistence}>
+            <Text style={styles.secondaryButtonText}>Vérifier la persistance</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+  },
+  headerGradient: {
+    paddingVertical: 24,
+    paddingHorizontal: 20,
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+  },
+  backButton: {
+    alignSelf: 'flex-start',
+    marginBottom: 12,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+  },
+  backButtonText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  headerTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: 'rgba(255, 255, 255, 0.8)',
+    marginTop: 4,
+  },
+  content: {
+    padding: 16,
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  textGroup: {
+    flex: 1,
+    marginRight: 12,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 4,
+  },
+  helperText: {
+    fontSize: 13,
+    color: '#6B7280',
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: '#111827',
+  },
+  persistenceText: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginBottom: 6,
+  },
+  persistenceDetail: {
+    fontSize: 14,
+    color: '#111827',
+    marginBottom: 4,
+  },
+  secondaryButton: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderColor: '#CBD5F5',
+    borderRadius: 10,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  secondaryButtonText: {
+    color: '#4F46E5',
+    fontWeight: '600',
+  },
+});

--- a/app/profile-settings.tsx
+++ b/app/profile-settings.tsx
@@ -1,0 +1,239 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSettings } from '@/contexts/SettingsContext';
+
+export default function ProfileSettingsScreen() {
+  const router = useRouter();
+  const { userSettings, updateUserSetting } = useSettings();
+  const [name, setName] = useState(userSettings.name);
+  const [age, setAge] = useState(userSettings.age);
+  const [persistedName, setPersistedName] = useState<string | null>(null);
+  const [persistedAge, setPersistedAge] = useState<string | null>(null);
+  const [persistenceMessage, setPersistenceMessage] = useState('');
+
+  useEffect(() => {
+    setName(userSettings.name);
+    setAge(userSettings.age);
+  }, [userSettings.name, userSettings.age]);
+
+  const ageError = useMemo(() => {
+    if (!age.trim()) return '';
+    const normalized = age.trim();
+    if (!/^[0-9]+$/.test(normalized)) {
+      return 'Veuillez saisir un âge numérique.';
+    }
+    if (parseInt(normalized, 10) <= 0) {
+      return 'Veuillez saisir un âge supérieur à 0.';
+    }
+    return '';
+  }, [age]);
+
+  const refreshPersistence = async () => {
+    try {
+      const storedSettings = await AsyncStorage.getItem('userSettings');
+      if (!storedSettings) {
+        setPersistedName(null);
+        setPersistedAge(null);
+        setPersistenceMessage('Aucune donnée persistée trouvée.');
+        return;
+      }
+      const parsed = JSON.parse(storedSettings);
+      setPersistedName(parsed?.name ?? '');
+      setPersistedAge(parsed?.age ?? '');
+      setPersistenceMessage('Données chargées depuis AsyncStorage.');
+    } catch (error) {
+      console.error('Erreur lors de la lecture AsyncStorage:', error);
+      setPersistenceMessage('Erreur lors de la lecture AsyncStorage.');
+    }
+  };
+
+  useEffect(() => {
+    refreshPersistence();
+  }, []);
+
+  const handleSave = async () => {
+    await updateUserSetting('name', name.trim());
+    await updateUserSetting('age', age.trim());
+    await refreshPersistence();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <LinearGradient colors={['#667EEA', '#764BA2']} style={styles.headerGradient}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Retour</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Profil</Text>
+        <Text style={styles.headerSubtitle}>Modifier votre nom et votre âge</Text>
+      </LinearGradient>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.card}>
+          <Text style={styles.label}>Nom</Text>
+          <TextInput
+            style={styles.input}
+            value={name}
+            onChangeText={setName}
+            placeholder="Votre nom"
+            placeholderTextColor="#9CA3AF"
+          />
+
+          <Text style={styles.label}>Âge</Text>
+          <TextInput
+            style={[styles.input, ageError ? styles.inputError : null]}
+            value={age}
+            onChangeText={setAge}
+            placeholder="Votre âge"
+            placeholderTextColor="#9CA3AF"
+            keyboardType="numeric"
+          />
+          {ageError ? <Text style={styles.errorText}>{ageError}</Text> : null}
+
+          <TouchableOpacity
+            style={[styles.saveButton, ageError ? styles.saveButtonDisabled : null]}
+            onPress={handleSave}
+            disabled={Boolean(ageError)}
+          >
+            <Text style={styles.saveButtonText}>Enregistrer</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.sectionTitle}>Test de persistance AsyncStorage</Text>
+          <Text style={styles.persistenceText}>{persistenceMessage}</Text>
+          <Text style={styles.persistenceDetail}>Nom sauvegardé : {persistedName ?? '—'}</Text>
+          <Text style={styles.persistenceDetail}>Âge sauvegardé : {persistedAge ?? '—'}</Text>
+          <TouchableOpacity style={styles.secondaryButton} onPress={refreshPersistence}>
+            <Text style={styles.secondaryButtonText}>Vérifier la persistance</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+  },
+  headerGradient: {
+    paddingVertical: 24,
+    paddingHorizontal: 20,
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+  },
+  backButton: {
+    alignSelf: 'flex-start',
+    marginBottom: 12,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+  },
+  backButtonText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  headerTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: 'rgba(255, 255, 255, 0.8)',
+    marginTop: 4,
+  },
+  content: {
+    padding: 16,
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  label: {
+    fontSize: 14,
+    color: '#6B7280',
+    marginBottom: 6,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    color: '#111827',
+    marginBottom: 12,
+  },
+  inputError: {
+    borderColor: '#EF4444',
+  },
+  errorText: {
+    color: '#EF4444',
+    fontSize: 12,
+    marginBottom: 8,
+  },
+  saveButton: {
+    backgroundColor: '#667EEA',
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  saveButtonDisabled: {
+    backgroundColor: '#C7D2FE',
+  },
+  saveButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: '#111827',
+  },
+  persistenceText: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginBottom: 6,
+  },
+  persistenceDetail: {
+    fontSize: 14,
+    color: '#111827',
+    marginBottom: 4,
+  },
+  secondaryButton: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderColor: '#CBD5F5',
+    borderRadius: 10,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  secondaryButtonText: {
+    color: '#4F46E5',
+    fontWeight: '600',
+  },
+});

--- a/app/targets.tsx
+++ b/app/targets.tsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useSettings } from '@/contexts/SettingsContext';
+
+export default function TargetsScreen() {
+  const router = useRouter();
+  const { userSettings, updateUserSetting } = useSettings();
+  const [targetMin, setTargetMin] = useState(userSettings.targetMin);
+  const [targetMax, setTargetMax] = useState(userSettings.targetMax);
+  const [persistedMin, setPersistedMin] = useState<string | null>(null);
+  const [persistedMax, setPersistedMax] = useState<string | null>(null);
+  const [persistenceMessage, setPersistenceMessage] = useState('');
+
+  const unitLabel = userSettings.unit === 'mgdl' ? 'mg/dL' : 'mmol/L';
+
+  useEffect(() => {
+    setTargetMin(userSettings.targetMin);
+    setTargetMax(userSettings.targetMax);
+  }, [userSettings.targetMin, userSettings.targetMax]);
+
+  const normalizedMin = targetMin.replace(',', '.');
+  const normalizedMax = targetMax.replace(',', '.');
+
+  const validationError = useMemo(() => {
+    const minValue = parseFloat(normalizedMin);
+    const maxValue = parseFloat(normalizedMax);
+
+    if (!targetMin.trim() || !targetMax.trim()) {
+      return 'Les deux cibles sont requises.';
+    }
+    if (Number.isNaN(minValue) || Number.isNaN(maxValue)) {
+      return 'Les cibles doivent être numériques.';
+    }
+    if (minValue <= 0 || maxValue <= 0) {
+      return 'Les cibles doivent être supérieures à 0.';
+    }
+    if (minValue >= maxValue) {
+      return 'La cible minimale doit être inférieure à la cible maximale.';
+    }
+    return '';
+  }, [normalizedMin, normalizedMax, targetMin, targetMax]);
+
+  const refreshPersistence = async () => {
+    try {
+      const storedSettings = await AsyncStorage.getItem('userSettings');
+      if (!storedSettings) {
+        setPersistedMin(null);
+        setPersistedMax(null);
+        setPersistenceMessage('Aucune donnée persistée trouvée.');
+        return;
+      }
+      const parsed = JSON.parse(storedSettings);
+      setPersistedMin(parsed?.targetMin ?? '');
+      setPersistedMax(parsed?.targetMax ?? '');
+      setPersistenceMessage('Données chargées depuis AsyncStorage.');
+    } catch (error) {
+      console.error('Erreur lors de la lecture AsyncStorage:', error);
+      setPersistenceMessage('Erreur lors de la lecture AsyncStorage.');
+    }
+  };
+
+  useEffect(() => {
+    refreshPersistence();
+  }, []);
+
+  const handleSave = async () => {
+    await updateUserSetting('targetMin', normalizedMin);
+    await updateUserSetting('targetMax', normalizedMax);
+    await refreshPersistence();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <LinearGradient colors={['#667EEA', '#764BA2']} style={styles.headerGradient}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Retour</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Cibles glycémiques</Text>
+        <Text style={styles.headerSubtitle}>Définissez votre plage cible ({unitLabel})</Text>
+      </LinearGradient>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.card}>
+          <Text style={styles.label}>Cible minimale ({unitLabel})</Text>
+          <TextInput
+            style={[styles.input, validationError ? styles.inputError : null]}
+            value={targetMin}
+            onChangeText={setTargetMin}
+            keyboardType="numeric"
+            placeholder="Ex: 70"
+            placeholderTextColor="#9CA3AF"
+          />
+
+          <Text style={styles.label}>Cible maximale ({unitLabel})</Text>
+          <TextInput
+            style={[styles.input, validationError ? styles.inputError : null]}
+            value={targetMax}
+            onChangeText={setTargetMax}
+            keyboardType="numeric"
+            placeholder="Ex: 140"
+            placeholderTextColor="#9CA3AF"
+          />
+
+          {validationError ? <Text style={styles.errorText}>{validationError}</Text> : null}
+
+          <TouchableOpacity
+            style={[styles.saveButton, validationError ? styles.saveButtonDisabled : null]}
+            onPress={handleSave}
+            disabled={Boolean(validationError)}
+          >
+            <Text style={styles.saveButtonText}>Enregistrer</Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.sectionTitle}>Test de persistance AsyncStorage</Text>
+          <Text style={styles.persistenceText}>{persistenceMessage}</Text>
+          <Text style={styles.persistenceDetail}>Cible min sauvegardée : {persistedMin ?? '—'} {unitLabel}</Text>
+          <Text style={styles.persistenceDetail}>Cible max sauvegardée : {persistedMax ?? '—'} {unitLabel}</Text>
+          <TouchableOpacity style={styles.secondaryButton} onPress={refreshPersistence}>
+            <Text style={styles.secondaryButtonText}>Vérifier la persistance</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+  },
+  headerGradient: {
+    paddingVertical: 24,
+    paddingHorizontal: 20,
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+  },
+  backButton: {
+    alignSelf: 'flex-start',
+    marginBottom: 12,
+    backgroundColor: 'rgba(255, 255, 255, 0.2)',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+  },
+  backButtonText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  headerTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: 'rgba(255, 255, 255, 0.8)',
+    marginTop: 4,
+  },
+  content: {
+    padding: 16,
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  label: {
+    fontSize: 14,
+    color: '#6B7280',
+    marginBottom: 6,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    color: '#111827',
+    marginBottom: 12,
+  },
+  inputError: {
+    borderColor: '#EF4444',
+  },
+  errorText: {
+    color: '#EF4444',
+    fontSize: 12,
+    marginBottom: 8,
+  },
+  saveButton: {
+    backgroundColor: '#667EEA',
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  saveButtonDisabled: {
+    backgroundColor: '#C7D2FE',
+  },
+  saveButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: '#111827',
+  },
+  persistenceText: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginBottom: 6,
+  },
+  persistenceDetail: {
+    fontSize: 14,
+    color: '#111827',
+    marginBottom: 4,
+  },
+  secondaryButton: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderColor: '#CBD5F5',
+    borderRadius: 10,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  secondaryButtonText: {
+    color: '#4F46E5',
+    fontWeight: '600',
+  },
+});


### PR DESCRIPTION
### Motivation

- Provide dedicated settings screens to allow editing and persisting user profile, target ranges and notification preferences.  
- Reuse existing `SettingsContext` so UI edits update the centralized `userSettings` state and persist to storage.  
- Replace placeholder alerts in the settings list with actual navigation to detailed screens.  
- Add basic client-side validation to avoid invalid numeric inputs for age and target ranges.

### Description

- Added three new screens: `app/profile-settings.tsx`, `app/targets.tsx` and `app/notifications.tsx`, each reading from and writing to `SettingsContext` and displaying AsyncStorage persistence status.  
- Implemented basic validation: numeric and >0 checks for `age`, and numeric/min<max checks for target `targetMin`/`targetMax`.  
- Replaced placeholder toasts in `app/(tabs)/settings.tsx` with navigation calls using `router.push()` to `/profile-settings`, `/targets` and `/notifications`.  
- Registered the new routes in the app stack by adding `profile-settings`, `targets` and `notifications` to `app/_layout.tsx`.

### Testing

- No automated tests were executed as part of this change.  
- Basic manual checks implemented in each screen read persisted values from `AsyncStorage` and display persistence status messages.  
- Project compiles locally (changes committed); no CI run was triggered in this rollout.  
- Navigation to the new screens has been wired and tested locally by invoking the updated `navigateToProfile/Targets/Notifications` handlers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f953d8448332924f5d10323bc5a8)