### PR TITLE
History: Use userSettings for glucose unit label

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -8,13 +8,16 @@ import { useMeasurements, useDeleteMeasurement } from '@/hooks/useMeasurements';
 import type { GlucoseMeasurement } from '@/utils/storage';
 import { getGlucoseStatus } from '@/utils/glucose';
 import AdvancedChart from '@/components/AdvancedChart';
+import { useSettings } from '@/contexts/SettingsContext';
 
 
 function HistoryScreen() {
   const { data: measurements = [], isLoading, error } = useMeasurements();
   const deleteMeasurement = useDeleteMeasurement();
+  const { userSettings } = useSettings();
   const [filteredMeasurements, setFilteredMeasurements] = useState<GlucoseMeasurement[]>([]);
   const [selectedFilter, setSelectedFilter] = useState<'all' | 'today' | 'week' | 'month'>('all');
+  const unitLabel = userSettings.unit === 'mgdl' ? 'mg/dL' : 'mmol/L';
 
 
   useEffect(() => {
@@ -71,7 +74,7 @@ function HistoryScreen() {
       <View style={styles.measurementCard}>
         <View style={styles.measurementHeader}>
           <View style={styles.measurementLeft}>
-            <Text style={styles.measurementValue}>{measurement.value} mg/dL</Text>
+            <Text style={styles.measurementValue}>{measurement.value} {unitLabel}</Text>
             <Text style={styles.measurementType}>{measurement.type}</Text>
           </View>
           <View style={styles.measurementRight}>


### PR DESCRIPTION
### Motivation
- Make the History screen display the correct glucose unit label (`mg/dL` or `mmol/L`) according to the saved `userSettings.unit`.
- Remove a hardcoded unit string so the UI respects the user's preference and regional settings.
- Keep unit labeling consistent with other screens that already use `userSettings.unit`.

### Description
- Imported `useSettings` from `@/contexts/SettingsContext` into `app/(tabs)/history.tsx`.
- Derived `unitLabel` using `userSettings.unit === 'mgdl' ? 'mg/dL' : 'mmol/L'` and added it to the component state.
- Replaced the hardcoded `mg/dL` text in the measurement row with `{unitLabel}` so values display the configured unit.
- Changes were applied to `app/(tabs)/history.tsx`.

### Testing
- No automated tests were executed for this change.
- Manual UI verification is suggested to confirm the label and filters render correctly for both units.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fe6ee1548332ac69b4d6345529a9)