### PR TITLE
Switch cloud sync to PostgreSQL-only and remove Firestore paths

### DIFF
--- a/FIREBASE_SETUP.md
+++ b/FIREBASE_SETUP.md
@@ -1,5 +1,7 @@
 # Guide de Configuration Firebase pour GlycoFlex
 
+> **Note** : Le stockage Firebase/Firestore est désactivé. GlycoFlex utilise désormais PostgreSQL pour la persistance en ligne. Firebase est conservé uniquement pour l'authentification utilisateur. Consultez le `README.md` pour la configuration PostgreSQL.
+
 ## 🔥 Étapes de configuration Firebase
 
 ### 1. Créer un projet Firebase
@@ -21,6 +23,8 @@
    - Cliquez sur "Save"
 
 ### 3. Configurer Firestore Database
+
+> ⚠️ Cette étape est **optionnelle** et conservée pour compatibilité historique. La persistance en ligne est désormais assurée par PostgreSQL.
 
 1. **Allez dans "Firestore Database"**
 2. **Cliquez sur "Create database"**

--- a/GUIDE_FIREBASE.md
+++ b/GUIDE_FIREBASE.md
@@ -1,5 +1,7 @@
 # 🔥 Guide de Configuration Firebase pour GlycoFlex
 
+> **Note** : Le stockage Firebase/Firestore est désactivé. GlycoFlex utilise désormais PostgreSQL pour la persistance en ligne. Firebase est conservé uniquement pour l'authentification utilisateur. Consultez le `README.md` pour la configuration PostgreSQL.
+
 ## 1. Créer un projet Firebase
 
 ### Étape 1 : Aller sur Firebase Console
@@ -25,6 +27,8 @@
    - Cliquez "Save"
 
 ## 3. Configurer Firestore Database
+
+> ⚠️ Cette section est **optionnelle** et conservée pour compatibilité historique. La persistance en ligne est désormais assurée par PostgreSQL.
 
 ### Créer la base de données
 1. Allez dans "Firestore Database"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🩸 GlycoFlex - Application de Suivi Glycémique
 
-Une application mobile moderne pour le suivi de la glycémie avec synchronisation Firebase.
+Une application mobile moderne pour le suivi de la glycémie avec synchronisation PostgreSQL.
 
 ## 🚀 Fonctionnalités
 
@@ -16,11 +16,11 @@ Une application mobile moderne pour le suivi de la glycémie avec synchronisatio
 - Comparaison entre périodes
 - Statistiques détaillées
 
-### ☁️ Synchronisation Firebase
-- Sauvegarde automatique dans le cloud
+### ☁️ Synchronisation PostgreSQL
+- Sauvegarde automatique via API PostgreSQL
 - Synchronisation entre appareils
 - Mode hors ligne avec cache local
-- Backup automatique des données
+- Reprise automatique des opérations
 
 ### 🌍 Multilingue
 - Support français et anglais
@@ -33,33 +33,9 @@ Une application mobile moderne pour le suivi de la glycémie avec synchronisatio
 - Paramètres d'accessibilité
 - Notifications et rappels
 
-## 🔧 Configuration Firebase
-
-### 1. Créer un projet Firebase
-1. Allez sur [Firebase Console](https://console.firebase.google.com/)
-2. Créez un nouveau projet
-3. Activez Firestore Database
-4. Configurez les règles de sécurité
-
-### 2. Configuration de l'application
-1. Créez un fichier `.env` à la racine et ajoutez votre configuration Firebase :
-
-```
-EXPO_PUBLIC_FIREBASE_API_KEY=votre-api-key
-EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=votre-projet.firebaseapp.com
-EXPO_PUBLIC_FIREBASE_PROJECT_ID=votre-projet-id
-EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=votre-projet.appspot.com
-EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=123456789
-EXPO_PUBLIC_FIREBASE_APP_ID=votre-app-id
-```
-
-Les valeurs seront automatiquement lues par `config/firebase.ts`.
-
-Pour la CI/CD, configurez ces variables via `eas secret` ou GitHub Secrets.
-
 ## 🐘 Synchronisation PostgreSQL (Neon)
 
-Pour remplacer Firestore par une base PostgreSQL hébergée sur Neon, un petit service API doit être déployé. L'application mobile se connecte ensuite à cette API.
+L'application utilise PostgreSQL pour la persistance en ligne. Un service API doit être déployé pour exposer les opérations de synchronisation.
 
 ### 1. Configurer la base Neon
 1. Créez un projet sur [neon.com](https://neon.com).
@@ -84,23 +60,27 @@ npm run server:dev
 Ajoutez les variables suivantes dans `.env` côté mobile :
 
 ```
-EXPO_PUBLIC_SYNC_PROVIDER=postgres
 EXPO_PUBLIC_SYNC_API_URL=https://votre-api.exemple.com
 ```
 
-L'application utilisera alors PostgreSQL pour la persistance en ligne (les comptes utilisateurs restent gérés par Firebase Auth).
+L'application utilisera PostgreSQL pour la persistance en ligne (les comptes utilisateurs restent gérés par Firebase Auth).
 
-### 3. Règles Firestore
-```javascript
-rules_version = '2';
-service cloud.firestore {
-  match /databases/{database}/documents {
-    match /glucose_measurements/{document} {
-      allow read, write: if request.auth != null || resource.data.userId == 'anonymous';
-    }
-  }
-}
+## 🔐 Authentification Firebase (comptes utilisateurs)
+
+Firebase Auth reste utilisé pour l'identité et les jetons d'accès. Créez un fichier `.env` à la racine et ajoutez votre configuration Firebase :
+
 ```
+EXPO_PUBLIC_FIREBASE_API_KEY=votre-api-key
+EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=votre-projet.firebaseapp.com
+EXPO_PUBLIC_FIREBASE_PROJECT_ID=votre-projet-id
+EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=votre-projet.appspot.com
+EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=123456789
+EXPO_PUBLIC_FIREBASE_APP_ID=votre-app-id
+```
+
+Les valeurs seront automatiquement lues par `config/firebase.ts`.
+
+Pour la CI/CD, configurez ces variables via `eas secret` ou GitHub Secrets.
 
 ## 📱 Installation
 
@@ -133,27 +113,26 @@ npm run lint
 │   ├── (tabs)/            # Navigation par onglets
 │   └── _layout.tsx        # Layout principal
 ├── components/            # Composants réutilisables
-├── config/               # Configuration Firebase
+├── config/               # Configuration Firebase Auth
 ├── contexts/             # Contextes React
 ├── utils/                # Utilitaires
 │   ├── storage.ts        # Stockage local
-│   ├── firebaseStorage.ts # Stockage Firebase
-│   └── hybridStorage.ts  # Stockage hybride
+│   ├── postgresCloudStorage.ts # Synchronisation PostgreSQL
+│   └── storageManager.ts # Orchestrateur local/cloud
 └── locales/              # Traductions
 ```
 
 ### Stockage hybride
 L'application utilise un système de stockage hybride :
 - **Local** : AsyncStorage pour le cache et mode hors ligne
-- **Firebase** : Firestore pour la synchronisation cloud
+- **PostgreSQL** : Synchronisation via API sécurisée
 - **Automatique** : Basculement transparent selon la connectivité
 
 ## 🔒 Sécurité
 
 - Données chiffrées en transit
-- Authentification optionnelle
+- Authentification via Firebase Auth
 - Mode anonyme disponible
-- Règles Firestore configurables
 
 ## 📊 Export des données
 

--- a/app/(tabs)/syncSettings.tsx
+++ b/app/(tabs)/syncSettings.tsx
@@ -1,19 +1,13 @@
-import { Platform, StyleSheet, View, Text, Switch, TouchableOpacity, ActivityIndicator, TextInput } from 'react-native';
+import { StyleSheet, View, Text, Switch, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import React, { useState, useEffect } from 'react';
 import { LinearGradient } from 'expo-linear-gradient';
-import { CloudIcon, Lock, Key, RefreshCcw, AlertTriangle, Smartphone, X, ShieldCheck } from 'lucide-react-native';
+import { CloudIcon, Lock, RefreshCcw, AlertTriangle, ShieldCheck } from 'lucide-react-native';
 import { useTranslation } from 'react-i18next';
-import { EncryptionService } from '@/utils/secureCloudStorage';
 import { getCloudStorageProvider } from '@/utils/cloudStorageProvider';
-import { isPostgresProvider } from '@/utils/syncProvider';
 import { auth } from '@/config/firebase';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { ScrollView, FlatList } from 'react-native-gesture-handler';
-import * as SecureStore from 'expo-secure-store';
+import { ScrollView } from 'react-native-gesture-handler';
 import { useToast } from '@/hooks/useToast';
-
-const LOCAL_RECOVERY_PHRASE = 'recovery_phrase';
 
 export default function SyncSettingsScreen() {
   const { t } = useTranslation();
@@ -22,82 +16,39 @@ export default function SyncSettingsScreen() {
   const [syncing, setSyncing] = useState(false);
   const [lastSyncTime, setLastSyncTime] = useState<number | null>(null);
   const [pendingOperations, setPendingOperations] = useState(0);
-  const [hasConflicts, setHasConflicts] = useState(false);
-  const [recoveryPhraseCreated, setRecoveryPhraseCreated] = useState(false);
-  const [devices, setDevices] = useState<{id: string; name: string; lastActive: number; isCurrentDevice: boolean}[]>([]);
-  const [deviceLoading, setDeviceLoading] = useState(false);
-  const [phraseInput, setPhraseInput] = useState('');
-  const [backupLoading, setBackupLoading] = useState(false);
-  const [restoreLoading, setRestoreLoading] = useState(false);
-  const [legacyKeyInput, setLegacyKeyInput] = useState('');
-  const [migrationRunning, setMigrationRunning] = useState(false);
-  const [corruptedCounts, setCorruptedCounts] = useState<{corrupted:number; ignored:number}>({corrupted:0, ignored:0});
   const toast = useToast();
-  const postgresProvider = isPostgresProvider();
-  const { hybrid: cloudHybrid, cloud: cloudStorage } = getCloudStorageProvider();
-  
+  const { hybrid: cloudHybrid } = getCloudStorageProvider();
+
   useEffect(() => {
     loadSettings();
   }, []);
-  
+
   const loadSettings = async () => {
     setLoading(true);
     try {
-      console.log("🔄 Chargement des paramètres de synchronisation");
-      
-      // Vérifier si l'utilisateur est authentifié
+      console.log('🔄 Chargement des paramètres de synchronisation');
+
       if (!auth.currentUser) {
-        console.log("❌ Utilisateur non authentifié");
-        // Rediriger vers l'écran d'authentification ou afficher une invite de connexion
+        console.log('❌ Utilisateur non authentifié');
         setLoading(false);
         return;
       }
-      
-      console.log("👤 Utilisateur authentifié:", auth.currentUser.uid);
-      
-      // Charger l'état de la synchronisation
+
+      console.log('👤 Utilisateur authentifié:', auth.currentUser.uid);
+
       const enabled = await cloudHybrid.isSyncEnabled();
       setSyncEnabled(enabled);
-      console.log("🔄 Synchronisation activée:", enabled);
-      
-      // Obtenir l'heure de dernière synchronisation
+      console.log('🔄 Synchronisation activée:', enabled);
+
       const lastSync = await cloudHybrid.getLastSyncTime();
       setLastSyncTime(lastSync);
-      console.log("⏱️ Dernière synchronisation:", lastSync ? new Date(lastSync).toLocaleString() : "Jamais");
-      
-      // Vérifier les opérations en attente
+      console.log('⏱️ Dernière synchronisation:', lastSync ? new Date(lastSync).toLocaleString() : 'Jamais');
+
       const pendingCount = await cloudHybrid.getPendingOperationsCount();
       setPendingOperations(pendingCount);
-      console.log("📝 Opérations en attente:", pendingCount);
-      
-      if (!postgresProvider) {
-        // Vérifier les conflits
-        const { hasConflicts } = await cloudStorage.checkForConflicts();
-        setHasConflicts(hasConflicts);
-        console.log("⚠️ Conflits détectés:", hasConflicts);
-        
-        // Vérifier si la phrase de récupération existe
-        const hasRecoveryPhrase = await checkRecoveryPhrase();
-        setRecoveryPhraseCreated(hasRecoveryPhrase);
-        console.log("🔑 Phrase de récupération créée:", hasRecoveryPhrase);
-        
-        // Charger les appareils
-        await loadDevices();
+      console.log('📝 Opérations en attente:', pendingCount);
 
-        // Charger stats docs corrompus
-        try {
-          const corrupted = cloudStorage.getCorruptedDocIds().length;
-          const ignored = (await cloudStorage.getIgnoredCorruptedDocIds()).length;
-          setCorruptedCounts({ corrupted, ignored });
-        } catch {}
-      } else {
-        setHasConflicts(false);
-        setRecoveryPhraseCreated(false);
-        setDevices([]);
-        setCorruptedCounts({ corrupted: 0, ignored: 0 });
-      }
-      
-      console.log("✅ Paramètres de synchronisation chargés avec succès");
+      console.log('✅ Paramètres de synchronisation chargés avec succès');
     } catch (error) {
       console.error('❌ Échec du chargement des paramètres de synchronisation:', error);
       toast.show(t('common.error'), t('syncSettings.loadError'));
@@ -105,74 +56,36 @@ export default function SyncSettingsScreen() {
       setLoading(false);
     }
   };
-  
-  const checkRecoveryPhrase = async (): Promise<boolean> => {
-    try {
-      const phrase = await SecureStore.getItemAsync(LOCAL_RECOVERY_PHRASE);
-      return !!phrase;
-    } catch (error) {
-      return false;
-    }
-  };
-  
-  const loadDevices = async () => {
-    try {
-      setDeviceLoading(true);
-      const devicesList = await cloudStorage.getConnectedDevices();
-      // Map the property name from isCurrent to isCurrentDevice
-      setDevices(devicesList.map(device => ({
-        ...device,
-        isCurrentDevice: device.isCurrent
-      })));
-    } catch (error) {
-      console.error('Échec du chargement des appareils:', error);
-    } finally {
-      setDeviceLoading(false);
-    }
-  };
-  
+
   const toggleSync = async (value: boolean) => {
     try {
       setSyncing(true);
-      
-      // Si activation de la synchronisation et pas de phrase de récupération, en créer une
-      if (value && !recoveryPhraseCreated) {
-        await createRecoveryPhrase();
-      }
-      
       await cloudHybrid.setSyncEnabled(value);
       setSyncEnabled(value);
-      
+
       if (value) {
-        // Effectuer une synchronisation initiale
         await cloudHybrid.syncWithCloud();
         const lastSync = await cloudHybrid.getLastSyncTime();
         setLastSyncTime(lastSync);
-        
-        // Mettre à jour la liste des appareils
-        if (!postgresProvider) {
-          await loadDevices();
-        }
       }
     } catch (error) {
       console.error('Échec de la modification de la synchronisation:', error);
       toast.show(t('common.error'), t('syncSettings.toggleError'));
-      setSyncEnabled(!value); // Revenir à l'état précédent
+      setSyncEnabled(!value);
     } finally {
       setSyncing(false);
     }
   };
-  
+
   const syncNow = async () => {
     try {
-      console.log("🔄 Synchronisation manuelle démarrée");
+      console.log('🔄 Synchronisation manuelle démarrée');
       setSyncing(true);
-      
-      // Vérifier l'état de la connexion
+
       const netInfo = await import('@react-native-community/netinfo').then(m => m.default.fetch());
-      
+
       if (!netInfo.isConnected) {
-        console.log("❌ Pas de connexion internet");
+        console.log('❌ Pas de connexion internet');
         toast.show(
           t('common.error'),
           t('syncSettings.noInternetConnection'),
@@ -180,10 +93,9 @@ export default function SyncSettingsScreen() {
         );
         return;
       }
-      
-      // Vérifier l'état de l'authentification
+
       if (!auth.currentUser) {
-        console.log("❌ Utilisateur non authentifié");
+        console.log('❌ Utilisateur non authentifié');
         toast.show(
           t('common.error'),
           t('syncSettings.notLoggedIn'),
@@ -191,32 +103,20 @@ export default function SyncSettingsScreen() {
         );
         return;
       }
-      
-      console.log("👤 Synchronisation pour l'utilisateur:", auth.currentUser.uid);
-      
-      // Synchroniser avec le cloud
+
+      console.log('👤 Synchronisation pour l\'utilisateur:', auth.currentUser.uid);
+
       await cloudHybrid.syncWithCloud();
-      
-      // Recharger les données
+
       const lastSync = await cloudHybrid.getLastSyncTime();
       setLastSyncTime(lastSync);
-      console.log("⏱️ Nouvelle heure de synchronisation:", lastSync ? new Date(lastSync).toLocaleString() : "Erreur");
-      
+      console.log('⏱️ Nouvelle heure de synchronisation:', lastSync ? new Date(lastSync).toLocaleString() : 'Erreur');
+
       const pendingCount = await cloudHybrid.getPendingOperationsCount();
       setPendingOperations(pendingCount);
-      console.log("📝 Opérations en attente restantes:", pendingCount);
-      
-      if (!postgresProvider) {
-        // Vérifier les conflits
-        const { hasConflicts } = await cloudStorage.checkForConflicts();
-        setHasConflicts(hasConflicts);
-        console.log("⚠️ Conflits après synchronisation:", hasConflicts);
-        
-        // Mettre à jour la liste des appareils
-        await loadDevices();
-      }
-      
-      console.log("✅ Synchronisation manuelle terminée avec succès");
+      console.log('📝 Opérations en attente restantes:', pendingCount);
+
+      console.log('✅ Synchronisation manuelle terminée avec succès');
       toast.show(t('common.success'), t('syncSettings.syncSuccess'));
     } catch (error) {
       console.error('❌ Échec de la synchronisation:', error);
@@ -229,195 +129,6 @@ export default function SyncSettingsScreen() {
     }
   };
 
-  const backupEncryptionKey = async () => {
-    if (postgresProvider) {
-      toast.show(t('common.error'), t('syncSettings.postgresUnsupported'));
-      return;
-    }
-    if (!recoveryPhraseCreated) {
-      toast.show(t('common.error'), t('syncSettings.backupNeeded'));
-      return;
-    }
-    try {
-      setBackupLoading(true);
-      const phrase = await SecureStore.getItemAsync(LOCAL_RECOVERY_PHRASE);
-      if (!phrase) {
-        toast.show(t('common.error'), t('syncSettings.noPhraseFound'));
-        return;
-      }
-      await cloudHybrid.backupEncryptionKeyWithPhrase(phrase);
-      toast.show(t('common.success'), t('syncSettings.backupSuccess'));
-    } catch (e) {
-      toast.show(t('common.error'), t('syncSettings.backupError'));
-    } finally {
-      setBackupLoading(false);
-    }
-  };
-
-  const restoreEncryptionKey = async () => {
-    if (postgresProvider) {
-      toast.show(t('common.error'), t('syncSettings.postgresUnsupported'));
-      return;
-    }
-    if (!phraseInput.trim()) {
-      toast.show(t('common.error'), t('syncSettings.enterRecoveryPhrase'));
-      return;
-    }
-    try {
-      setRestoreLoading(true);
-      await cloudHybrid.restoreEncryptionKeyWithPhrase(phraseInput.trim());
-      toast.show(t('common.success'), t('syncSettings.restoreSuccess'));
-      // Après restauration, lancer une synchro
-      await cloudHybrid.syncWithCloud();
-      const lastSync = await cloudHybrid.getLastSyncTime();
-      setLastSyncTime(lastSync);
-    } catch (e) {
-      toast.show(t('common.error'), t('syncSettings.restoreError'));
-    } finally {
-      setRestoreLoading(false);
-    }
-  };
-
-  const addLegacyKey = async () => {
-    if (postgresProvider) {
-      toast.show(t('common.error'), t('syncSettings.postgresUnsupported'));
-      return;
-    }
-    if (!legacyKeyInput.trim()) return;
-    try {
-      await EncryptionService.addLegacyKeyCandidate(legacyKeyInput.trim());
-      toast.show(t('common.success'), 'Clé legacy ajoutée. Relancez une migration.');
-      setLegacyKeyInput('');
-    } catch (e) {
-      toast.show(t('common.error'), "Impossible d'ajouter la clé legacy");
-    }
-  };
-
-  const runMigrationScan = async () => {
-    if (postgresProvider) {
-      toast.show(t('common.error'), t('syncSettings.postgresUnsupported'));
-      return;
-    }
-    try {
-      setMigrationRunning(true);
-      const result = await cloudStorage.forceMigrationScan();
-      setCorruptedCounts({ corrupted: result.corrupted, ignored: result.ignored });
-      toast.show('Migration', `Cloud: ${result.totalCloud}\nCorrompus: ${result.corrupted}\nIgnorés: ${result.ignored}`);
-    } catch (e) {
-      toast.show(t('common.error'), 'Migration scan échoué');
-    } finally {
-      setMigrationRunning(false);
-    }
-  };
-  
-  const createRecoveryPhrase = async () => {
-    if (postgresProvider) {
-      toast.show(t('common.error'), t('syncSettings.postgresUnsupported'));
-      return;
-    }
-    try {
-      // Générer une phrase de récupération de 12 mots
-      const wordList = [
-        'pomme', 'banane', 'cerise', 'date', 'sureau', 'figue',
-        'raisin', 'miel', 'iris', 'jade', 'kiwi', 'citron',
-        'mangue', 'noix', 'orange', 'poire', 'coing', 'framboise',
-        'fraise', 'tomate', 'raisin', 'noix', 'xanthium', 'yaourt',
-        'zeste', 'abricot', 'bleuet', 'canneberge', 'datte', 'figue'
-      ];
-      
-      // Générer 12 mots aléatoires
-      const phrase = Array(12)
-        .fill(0)
-        .map(() => wordList[Math.floor(Math.random() * wordList.length)])
-        .join(' ');
-      
-      // Stocker localement dans un stockage sécurisé
-      await SecureStore.setItemAsync(LOCAL_RECOVERY_PHRASE, phrase);
-      setRecoveryPhraseCreated(true);
-      
-      // Sauvegarder la clé d'encryption (normalement avec la phrase comme protection)
-      const key = await EncryptionService.exportEncryptionKey();
-      
-      // Ici, nous pourrions chiffrer la clé avec la phrase et la sauvegarder dans Firebase
-      // Pour simplifier, nous montrons juste la phrase à l'utilisateur
-      
-      // Montrer la phrase de récupération à l'utilisateur
-      toast.show(
-        t('syncSettings.recoveryPhraseTitle'),
-        t('syncSettings.recoveryPhraseMessage', { phrase }),
-        [
-          {
-            text: t('syncSettings.phraseConfirm'),
-            onPress: () => console.log('Phrase de récupération sauvegardée')
-          }
-        ]
-      );
-    } catch (error) {
-      console.error('Échec de la création de la phrase de récupération:', error);
-      toast.show(t('common.error'), t('syncSettings.recoveryPhraseError'));
-    }
-  };
-  
-  const showRecoveryPhrase = async () => {
-    if (postgresProvider) {
-      toast.show(t('common.error'), t('syncSettings.postgresUnsupported'));
-      return;
-    }
-    try {
-      const phrase = await SecureStore.getItemAsync(LOCAL_RECOVERY_PHRASE);
-      if (phrase) {
-        toast.show(
-          t('syncSettings.recoveryPhrase'),
-          t('syncSettings.recoveryPhraseShow', { phrase }),
-          [
-            {
-              text: t('common.ok'),
-              onPress: () => console.log('Phrase de récupération consultée')
-            }
-          ]
-        );
-      } else {
-        toast.show(t('common.error'), t('syncSettings.noPhraseFound'));
-      }
-    } catch (error) {
-      console.error('Échec de l\'affichage de la phrase de récupération:', error);
-      toast.show(t('common.error'), t('syncSettings.showPhraseError'));
-    }
-  };
-  
-  const removeDevice = async (deviceId: string) => {
-    if (postgresProvider) {
-      toast.show(t('common.error'), t('syncSettings.postgresUnsupported'));
-      return;
-    }
-    try {
-      await cloudStorage.removeDevice(deviceId);
-      setDevices(devices.filter(d => d.id !== deviceId));
-      toast.show(t('common.success'), t('syncSettings.deviceRemoved'));
-    } catch (error) {
-      console.error('Échec de la suppression de l\'appareil:', error);
-      toast.show(t('common.error'), t('syncSettings.deviceRemoveError'));
-    }
-  };
-  
-  const confirmRemoveDevice = (device: {id: string; name: string}) => {
-    toast.show(
-      t('syncSettings.removeDevice'),
-      t('syncSettings.removeDeviceConfirm', { name: device.name }),
-      [
-        {
-          text: t('common.cancel'),
-          style: 'cancel'
-        },
-        {
-          text: t('common.remove'),
-          onPress: () => removeDevice(device.id),
-          style: 'destructive'
-        }
-      ]
-    );
-  };
-  
   if (loading) {
     return (
       <View style={styles.loadingContainer}>
@@ -426,7 +137,7 @@ export default function SyncSettingsScreen() {
       </View>
     );
   }
-  
+
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView>
@@ -442,20 +153,20 @@ export default function SyncSettingsScreen() {
           <View style={styles.providerBadge}>
             <ShieldCheck size={16} color="#667EEA" />
             <Text style={styles.providerText}>
-              {postgresProvider ? t('syncSettings.postgresProviderLabel') : t('syncSettings.firebaseProviderLabel')}
+              {t('syncSettings.postgresProviderLabel')}
             </Text>
           </View>
-          
+
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
               <CloudIcon size={20} color="#667EEA" />
               <Text style={styles.sectionTitle}>{t('syncSettings.cloudSync')}</Text>
             </View>
-            
+
             <Text style={styles.description}>
               {t('syncSettings.cloudSyncDescription')}
             </Text>
-            
+
             <View style={styles.switchContainer}>
               <Text style={styles.switchLabel}>{t('syncSettings.enableSync')}</Text>
               <Switch
@@ -466,7 +177,7 @@ export default function SyncSettingsScreen() {
                 thumbColor={syncEnabled ? '#FFFFFF' : '#F3F4F6'}
               />
             </View>
-            
+
             {!auth.currentUser && (
               <View style={styles.warningContainer}>
                 <AlertTriangle size={16} color="#FF6B35" />
@@ -475,7 +186,7 @@ export default function SyncSettingsScreen() {
                 </Text>
               </View>
             )}
-            
+
             {syncEnabled && (
               <>
                 <View style={styles.infoContainer}>
@@ -483,12 +194,12 @@ export default function SyncSettingsScreen() {
                     {t('syncSettings.lastSynced')}:
                   </Text>
                   <Text style={styles.infoValue}>
-                    {lastSyncTime 
+                    {lastSyncTime
                       ? new Date(lastSyncTime).toLocaleString()
                       : t('syncSettings.never')}
                   </Text>
                 </View>
-                
+
                 {pendingOperations > 0 && (
                   <View style={styles.infoContainer}>
                     <Text style={styles.infoLabel}>
@@ -499,7 +210,7 @@ export default function SyncSettingsScreen() {
                     </Text>
                   </View>
                 )}
-                
+
                 <TouchableOpacity
                   style={[styles.syncButton, syncing && styles.syncButtonDisabled]}
                   onPress={syncNow}
@@ -511,223 +222,24 @@ export default function SyncSettingsScreen() {
                     <RefreshCcw size={18} color="#FFFFFF" />
                   )}
                   <Text style={styles.syncButtonText}>
-                    {syncing 
+                    {syncing
                       ? t('syncSettings.syncing')
                       : t('syncSettings.syncNow')}
                   </Text>
                 </TouchableOpacity>
-                
-                {hasConflicts && (
-                  <View style={styles.warningContainer}>
-                    <AlertTriangle size={16} color="#FF6B35" />
-                    <Text style={styles.warningText}>
-                      {t('syncSettings.conflictsDetected')}
-                    </Text>
-                  </View>
-                )}
               </>
             )}
           </View>
-          
-          {postgresProvider ? (
-            <View style={styles.section}>
-              <View style={styles.sectionHeader}>
-                <Lock size={20} color="#667EEA" />
-                <Text style={styles.sectionTitle}>{t('syncSettings.postgresSecurityTitle')}</Text>
-              </View>
-              <Text style={styles.description}>
-                {t('syncSettings.postgresSecurityDescription')}
-              </Text>
-            </View>
-          ) : (
-            <View style={styles.section}>
-              <View style={styles.sectionHeader}>
-                <Lock size={20} color="#667EEA" />
-                <Text style={styles.sectionTitle}>{t('syncSettings.security')}</Text>
-              </View>
-              
-              <Text style={styles.description}>
-                {t('syncSettings.securityDescription')}
-              </Text>
-              
-              <View style={styles.securityInfo}>
-                <View style={styles.securityItem}>
-                  <Lock size={16} color="#667EEA" />
-                  <Text style={styles.securityText}>
-                    {t('syncSettings.endToEndEncryption')}
-                  </Text>
-                </View>
-                
-                <View style={styles.securityItem}>
-                  <Key size={16} color="#667EEA" />
-                  <Text style={styles.securityText}>
-                    {t('syncSettings.uniqueEncryptionKey')}
-                  </Text>
-                </View>
-              </View>
-              
-              <View style={styles.recoverySection}>
-                <Text style={styles.recoveryTitle}>
-                  {t('syncSettings.recoveryPhrase')}
-                </Text>
-                
-                <Text style={styles.recoveryDescription}>
-                  {t('syncSettings.recoveryDescription')}
-                </Text>
-                
-                {recoveryPhraseCreated ? (
-                  <TouchableOpacity
-                    style={styles.recoveryButton}
-                    onPress={showRecoveryPhrase}
-                  >
-                    <Key size={18} color="#FFFFFF" />
-                    <Text style={styles.recoveryButtonText}>
-                      {t('syncSettings.viewRecoveryPhrase')}
-                    </Text>
-                  </TouchableOpacity>
-                ) : (
-                  <TouchableOpacity
-                    style={styles.recoveryButton}
-                    onPress={createRecoveryPhrase}
-                  >
-                    <Key size={18} color="#FFFFFF" />
-                    <Text style={styles.recoveryButtonText}>
-                      {t('syncSettings.createRecoveryPhrase')}
-                    </Text>
-                  </TouchableOpacity>
-                )}
 
-                {recoveryPhraseCreated && (
-                  <>
-                    <View style={styles.backupContainer}>
-                      <TouchableOpacity
-                        style={[styles.secondaryButton, backupLoading && styles.disabledButton]}
-                        disabled={backupLoading}
-                        onPress={backupEncryptionKey}
-                      >
-                        {backupLoading ? (
-                          <ActivityIndicator size="small" color="#FFFFFF" />
-                        ) : (
-                          <ShieldCheck size={18} color="#FFFFFF" />
-                        )}
-                        <Text style={styles.secondaryButtonText}>
-                          {backupLoading ? t('syncSettings.backupInProgress') : t('syncSettings.backupKey')}
-                        </Text>
-                      </TouchableOpacity>
-                    </View>
-                    <View style={styles.restoreBlock}>
-                      <Text style={styles.restoreLabel}>{t('syncSettings.restoreKeyDescription')}</Text>
-                      <TextInput
-                        style={styles.phraseInput}
-                        placeholder={t('syncSettings.enterPhrasePlaceholder')}
-                        placeholderTextColor="#888"
-                        multiline
-                        value={phraseInput}
-                        onChangeText={setPhraseInput}
-                      />
-                      <TouchableOpacity
-                        style={[styles.secondaryOutlineButton, restoreLoading && styles.disabledOutlineButton]}
-                        disabled={restoreLoading}
-                        onPress={restoreEncryptionKey}
-                      >
-                        {restoreLoading ? (
-                          <ActivityIndicator size="small" color="#667EEA" />
-                        ) : (
-                          <ShieldCheck size={18} color="#667EEA" />
-                        )}
-                        <Text style={styles.secondaryOutlineButtonText}>
-                          {restoreLoading ? t('syncSettings.restoreInProgress') : t('syncSettings.restoreKey')}
-                        </Text>
-                      </TouchableOpacity>
-                    </View>
-                    <View style={styles.migrationBlock}>
-                      <Text style={styles.migrationTitle}>Migration & Clés legacy</Text>
-                      <Text style={styles.migrationDesc}>Ajoutez une ancienne clé si certaines données historiques ne se déchiffrent plus, puis lancez un scan.</Text>
-                      <TextInput
-                        style={styles.legacyInput}
-                        placeholder="Ancienne clé (optionnel)"
-                        placeholderTextColor="#888"
-                        value={legacyKeyInput}
-                        onChangeText={setLegacyKeyInput}
-                      />
-                      <View style={styles.migrationButtonsRow}>
-                        <TouchableOpacity
-                          style={[styles.smallButton, !legacyKeyInput.trim() && styles.smallButtonDisabled]}
-                          disabled={!legacyKeyInput.trim()}
-                          onPress={addLegacyKey}
-                        >
-                          <Text style={styles.smallButtonText}>Ajouter clé</Text>
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                          style={[styles.smallButtonOutline, migrationRunning && styles.smallButtonDisabled]}
-                          disabled={migrationRunning}
-                          onPress={runMigrationScan}
-                        >
-                          {migrationRunning ? <ActivityIndicator size="small" color="#667EEA" /> : <Text style={styles.smallButtonOutlineText}>Scan migration</Text>}
-                        </TouchableOpacity>
-                      </View>
-                      <Text style={styles.migrationStats}>Corrompus détectés: {corruptedCounts.corrupted} • Ignorés: {corruptedCounts.ignored}</Text>
-                    </View>
-                  </>
-                )}
-              </View>
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Lock size={20} color="#667EEA" />
+              <Text style={styles.sectionTitle}>{t('syncSettings.postgresSecurityTitle')}</Text>
             </View>
-          )}
-          
-          {syncEnabled && !postgresProvider && (
-            <View style={styles.section}>
-              <View style={styles.sectionHeader}>
-                <Smartphone size={20} color="#667EEA" />
-                <Text style={styles.sectionTitle}>{t('syncSettings.connectedDevices')}</Text>
-              </View>
-              
-              {deviceLoading ? (
-                <ActivityIndicator size="small" color="#667EEA" style={styles.deviceLoading} />
-              ) : devices.length === 0 ? (
-                <Text style={styles.emptyText}>{t('syncSettings.noDevices')}</Text>
-              ) : (
-                devices.map((device) => (
-                  <View key={device.id} style={styles.deviceItem}>
-                    <View style={styles.deviceInfo}>
-                      <Smartphone size={18} color="#667EEA" />
-                      <View style={styles.deviceDetails}>
-                        <Text style={styles.deviceName}>
-                          {device.name} {device.isCurrentDevice && `(${t('syncSettings.thisDevice')})`}
-                        </Text>
-                        <Text style={styles.deviceActive}>
-                          {t('syncSettings.lastActive')}: {new Date(device.lastActive).toLocaleString()}
-                        </Text>
-                      </View>
-                    </View>
-                    
-                    {!device.isCurrentDevice && (
-                      <TouchableOpacity
-                        style={styles.removeButton}
-                        onPress={() => confirmRemoveDevice(device)}
-                      >
-                        <X size={16} color="#F56565" />
-                      </TouchableOpacity>
-                    )}
-                  </View>
-                ))
-              )}
-              
-              <TouchableOpacity
-                style={styles.refreshButton}
-                onPress={loadDevices}
-                disabled={deviceLoading}
-              >
-                {deviceLoading ? (
-                  <ActivityIndicator size="small" color="#667EEA" />
-                ) : (
-                  <RefreshCcw size={16} color="#667EEA" />
-                )}
-                <Text style={styles.refreshText}>
-                  {t('syncSettings.refreshDevices')}
-                </Text>
-              </TouchableOpacity>
-            </View>
-          )}
+            <Text style={styles.description}>
+              {t('syncSettings.postgresSecurityDescription')}
+            </Text>
+          </View>
         </LinearGradient>
       </ScrollView>
     </SafeAreaView>
@@ -867,234 +379,5 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '500',
     marginLeft: 8
-  },
-  securityInfo: {
-    marginVertical: 8
-  },
-  securityItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginVertical: 6
-  },
-  securityText: {
-    fontSize: 14,
-    color: '#333',
-    marginLeft: 8
-  },
-  recoverySection: {
-    marginTop: 16,
-    paddingTop: 16,
-    borderTopWidth: 1,
-    borderTopColor: 'rgba(0,0,0,0.05)'
-  },
-  recoveryTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#333',
-    marginBottom: 8
-  },
-  recoveryDescription: {
-    fontSize: 14,
-    color: '#666',
-    marginBottom: 12,
-    lineHeight: 20
-  },
-  recoveryButton: {
-    backgroundColor: '#667EEA',
-    borderRadius: 8,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 10
-  },
-  recoveryButtonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '500',
-    marginLeft: 8
-  },
-  emptyText: {
-    fontSize: 14,
-    color: '#666',
-    fontStyle: 'italic',
-    textAlign: 'center',
-    paddingVertical: 16
-  },
-  deviceLoading: {
-    marginVertical: 16
-  },
-  deviceItem: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: 'rgba(0,0,0,0.05)'
-  },
-  deviceInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1
-  },
-  deviceDetails: {
-    marginLeft: 10,
-    flex: 1
-  },
-  deviceName: {
-    fontSize: 15,
-    fontWeight: '500',
-    color: '#333'
-  },
-  deviceActive: {
-    fontSize: 13,
-    color: '#666',
-    marginTop: 2
-  },
-  removeButton: {
-    padding: 8,
-    borderRadius: 20,
-    backgroundColor: 'rgba(245, 101, 101, 0.1)'
-  },
-  refreshButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 10,
-    marginTop: 12
-  },
-  refreshText: {
-    color: '#667EEA',
-    marginLeft: 6,
-    fontSize: 14
-  },
-  backupContainer: {
-    marginTop: 16
-  },
-  secondaryButton: {
-    backgroundColor: '#764BA2',
-    borderRadius: 8,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 12
-  },
-  disabledButton: {
-    opacity: 0.6
-  },
-  secondaryButtonText: {
-    color: '#FFFFFF',
-    fontSize: 14,
-    fontWeight: '500',
-    marginLeft: 8
-  },
-  restoreBlock: {
-    marginTop: 20,
-    borderTopWidth: 1,
-    borderTopColor: 'rgba(0,0,0,0.05)',
-    paddingTop: 16
-  },
-  restoreLabel: {
-    fontSize: 14,
-    color: '#555',
-    marginBottom: 8
-  },
-  phraseInput: {
-    minHeight: 70,
-    borderWidth: 1,
-    borderColor: 'rgba(0,0,0,0.15)',
-    borderRadius: 8,
-    padding: 10,
-    color: '#333',
-    backgroundColor: '#FFFFFF',
-    textAlignVertical: 'top',
-    marginBottom: 12
-  },
-  secondaryOutlineButton: {
-    borderWidth: 1,
-    borderColor: '#667EEA',
-    borderRadius: 8,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    backgroundColor: 'rgba(255,255,255,0.9)'
-  },
-  disabledOutlineButton: {
-    opacity: 0.6
-  },
-  secondaryOutlineButtonText: {
-    color: '#667EEA',
-    fontSize: 14,
-    fontWeight: '500',
-    marginLeft: 8
-  },
-  migrationBlock: {
-    marginTop: 24,
-    borderTopWidth: 1,
-    borderTopColor: 'rgba(0,0,0,0.05)',
-    paddingTop: 16
-  },
-  migrationTitle: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: '#333',
-    marginBottom: 6
-  },
-  migrationDesc: {
-    fontSize: 13,
-    color: '#555',
-    marginBottom: 10,
-    lineHeight: 18
-  },
-  legacyInput: {
-    borderWidth: 1,
-    borderColor: 'rgba(0,0,0,0.15)',
-    borderRadius: 8,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-    backgroundColor: '#FFFFFF',
-    color: '#333',
-    marginBottom: 12
-  },
-  migrationButtonsRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    gap: 12,
-    marginBottom: 10
-  },
-  smallButton: {
-    flex: 1,
-    backgroundColor: '#764BA2',
-    paddingVertical: 10,
-    borderRadius: 8,
-    alignItems: 'center'
-  },
-  smallButtonOutline: {
-    flex: 1,
-    borderWidth: 1,
-    borderColor: '#667EEA',
-    paddingVertical: 10,
-    borderRadius: 8,
-    alignItems: 'center',
-    backgroundColor: 'rgba(255,255,255,0.9)'
-  },
-  smallButtonDisabled: {
-    opacity: 0.5
-  },
-  smallButtonText: {
-    color: '#FFFFFF',
-    fontSize: 14,
-    fontWeight: '500'
-  },
-  smallButtonOutlineText: {
-    color: '#667EEA',
-    fontSize: 14,
-    fontWeight: '500'
-  },
-  migrationStats: {
-    fontSize: 12,
-    color: '#555'
   }
 });

--- a/components/StorageDiagnostic.tsx
+++ b/components/StorageDiagnostic.tsx
@@ -1,15 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { Database, Cloud, AlertTriangle, CheckCircle, RefreshCw, Trash2, Upload, Shield } from 'lucide-react-native';
+import { Database, Cloud, AlertTriangle, CheckCircle, RefreshCw } from 'lucide-react-native';
 import { StorageManager } from '@/utils/storageManager';
-import { EncryptionService, CorruptionCircuitBreaker } from '@/utils/secureCloudStorage';
-import { markProblematicDocumentsAsCorrupted } from '@/utils/cleanupTools';
-import { SyncDiagnostic } from '@/utils/syncDiagnostic';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/useToast';
 import { getCloudStorageProvider } from '@/utils/cloudStorageProvider';
-import { isPostgresProvider } from '@/utils/syncProvider';
 
 interface StorageStats {
   localCount: number;
@@ -20,12 +16,8 @@ interface StorageStats {
 }
 
 interface DiagnosticInfo {
-  encryptionKeyInitialized: boolean;
-  corruptedDocs: string[];
-  ignoredDocs: string[];
   cloudConnectivity: boolean;
   userAuthenticated: boolean;
-  circuitBreakerStatus: string;
 }
 
 export default function StorageDiagnostic() {
@@ -35,7 +27,6 @@ export default function StorageDiagnostic() {
   const [loading, setLoading] = useState(true);
   const [actionInProgress, setActionInProgress] = useState<string | null>(null);
   const toast = useToast();
-  const postgresProvider = isPostgresProvider();
   const { cloud: cloudStorage } = getCloudStorageProvider();
 
   useEffect(() => {
@@ -45,46 +36,21 @@ export default function StorageDiagnostic() {
   const loadDiagnosticData = async () => {
     setLoading(true);
     try {
-      // Charger les statistiques de stockage
       const storageStats = await StorageManager.getStorageStats();
       setStats(storageStats);
 
-      // Diagnostic approfondi
       const diagInfo: DiagnosticInfo = {
-        encryptionKeyInitialized: false,
-        corruptedDocs: [],
-        ignoredDocs: [],
         cloudConnectivity: false,
         userAuthenticated: !!user,
-        circuitBreakerStatus: postgresProvider ? 'PostgreSQL' : await CorruptionCircuitBreaker.getStatus()
       };
 
-      if (!postgresProvider) {
+      if (user) {
         try {
-          // Tester l'initialisation de la clé d'encryption
-          await EncryptionService.initializeEncryptionKey();
-          diagInfo.encryptionKeyInitialized = true;
-        } catch (error) {
-          console.error('Erreur initialisation clé:', error);
-        }
-
-        try {
-          // Récupérer les documents corrompus
-          diagInfo.corruptedDocs = cloudStorage.getCorruptedDocIds();
-          diagInfo.ignoredDocs = await cloudStorage.getIgnoredCorruptedDocIds();
-        } catch (error) {
-          console.error('Erreur récupération docs corrompus:', error);
-        }
-      }
-
-      try {
-        // Tester la connectivité cloud
-        if (user) {
           await cloudStorage.getMeasurements();
           diagInfo.cloudConnectivity = true;
+        } catch (error) {
+          console.error('Erreur connectivité cloud:', error);
         }
-      } catch (error) {
-        console.error('Erreur connectivité cloud:', error);
       }
 
       setDiagnostic(diagInfo);
@@ -115,93 +81,6 @@ export default function StorageDiagnostic() {
     }
   };
 
-  const handleCleanupCorrupted = async () => {
-    if (postgresProvider) {
-      toast.show('Info', 'Nettoyage des documents corrompus indisponible avec PostgreSQL');
-      return;
-    }
-    if (!user) {
-      toast.show('Erreur', 'Vous devez être connecté pour nettoyer');
-      return;
-    }
-
-    toast.show(
-      'Confirmation',
-      'Voulez-vous marquer les documents corrompus pour nettoyage ?',
-      [
-        { text: 'Annuler', style: 'cancel' },
-        { text: 'Confirmer', onPress: performCleanup }
-      ]
-    );
-  };
-
-  const performCleanup = async () => {
-    setActionInProgress('cleanup');
-    try {
-      await markProblematicDocumentsAsCorrupted();
-      toast.show('Succès', 'Documents corrompus marqués pour nettoyage');
-      await loadDiagnosticData();
-    } catch (error) {
-      console.error('Erreur nettoyage:', error);
-      toast.show('Erreur', 'Échec du nettoyage des documents corrompus');
-    } finally {
-      setActionInProgress(null);
-    }
-  };
-
-  const handleRunFullDiagnostic = async () => {
-    if (postgresProvider) {
-      toast.show('Info', 'Diagnostic avancé indisponible avec PostgreSQL');
-      return;
-    }
-    setActionInProgress('diagnostic');
-    try {
-      const fullDiagnostic = await SyncDiagnostic.fullDiagnostic();
-      console.log('📋 Diagnostic complet:', fullDiagnostic);
-      
-      let message = `Diagnostic terminé.\n\n`;
-      message += `Utilisateur: ${fullDiagnostic.user?.authenticated ? 'Connecté' : 'Non connecté'}\n`;
-      message += `Mesures locales: ${fullDiagnostic.storage?.count || 0}\n`;
-      message += `Mesures cloud: ${fullDiagnostic.cloud?.count || 0}\n`;
-      message += `Problèmes: ${fullDiagnostic.issues?.length || 0}\n`;
-      
-      if (fullDiagnostic.issues?.length > 0) {
-        message += `\nProblèmes détectés:\n• ${fullDiagnostic.issues.join('\n• ')}`;
-      }
-      
-      toast.show('Diagnostic Complet', message);
-      await loadDiagnosticData();
-    } catch (error) {
-      console.error('Erreur diagnostic complet:', error);
-      toast.show('Erreur', 'Échec du diagnostic complet');
-    } finally {
-      setActionInProgress(null);
-    }
-  };
-
-  const handleForceSyncLocal = async () => {
-    if (postgresProvider) {
-      toast.show('Info', 'Synchronisation forcée indisponible avec PostgreSQL');
-      return;
-    }
-    if (!user) {
-      toast.show('Erreur', 'Vous devez être connecté pour synchroniser');
-      return;
-    }
-
-    setActionInProgress('force-sync-local');
-    try {
-      await SyncDiagnostic.forceSyncLocalToCloud();
-      toast.show('Succès', 'Synchronisation forcée des données locales terminée');
-      await loadDiagnosticData();
-    } catch (error) {
-      console.error('Erreur force sync local:', error);
-      toast.show('Erreur', 'Échec de la synchronisation forcée');
-    } finally {
-      setActionInProgress(null);
-    }
-  };
-
   const handleResetStorage = async () => {
     toast.show(
       'Attention !',
@@ -213,68 +92,10 @@ export default function StorageDiagnostic() {
     );
   };
 
-  const handleUnblockUploads = async () => {
-    console.log('🚨 BOUTON DÉBLOQUER UPLOADS CLIQUÉ !');
-    if (postgresProvider) {
-      toast.show('Info', 'Déblocage des uploads indisponible avec PostgreSQL');
-      return;
-    }
-    if (!user) {
-      toast.show('Erreur', 'Vous devez être connecté pour débloquer les uploads');
-      return;
-    }
-
-    await performUnblockUploads();
-  };
-
-  const performUnblockUploads = async () => {
-    setActionInProgress('unblock');
-    try {
-      console.log('🧹 Début du nettoyage radical...');
-      const { SecureHybridStorage } = await import('@/utils/secureCloudStorage');
-      await SecureHybridStorage.forceUploadBlockedMeasurements();
-      
-      // Essayer la synchronisation
-      try {
-        await StorageManager.forceSyncNow();
-        toast.show('Succès', 'Uploads débloqués et synchronisation lancée');
-      } catch (syncError) {
-        console.warn('Sync échouée après nettoyage:', syncError);
-        toast.show('Info', "Nettoyage effectué. Redémarrez l'app pour finaliser.");
-      }
-      
-      await loadDiagnosticData();
-    } catch (error) {
-      console.error('Erreur déblocage uploads:', error);
-      toast.show('Erreur', 'Échec du déblocage: ' + String(error));
-    } finally {
-      setActionInProgress(null);
-    }
-  };
-
-  const handleResetCircuitBreaker = async () => {
-    if (postgresProvider) {
-      toast.show('Info', 'Circuit breaker indisponible avec PostgreSQL');
-      return;
-    }
-    setActionInProgress('circuit-reset');
-    try {
-      await CorruptionCircuitBreaker.reset();
-      toast.show('Succès', 'Circuit breaker réinitialisé avec succès');
-      await loadDiagnosticData();
-    } catch (error) {
-      console.error('Erreur reset circuit breaker:', error);
-      toast.show('Erreur', 'Échec du reset: ' + String(error));
-    } finally {
-      setActionInProgress(null);
-    }
-  };
-
   const performReset = async () => {
     setActionInProgress('reset');
     try {
       await StorageManager.cleanup();
-      await SyncDiagnostic.cleanupSyncData();
       toast.show('Succès', 'Stockage réinitialisé avec succès');
       await loadDiagnosticData();
     } catch (error) {
@@ -314,7 +135,6 @@ export default function StorageDiagnostic() {
         <View style={styles.content}>
           <Text style={styles.title}>Diagnostic de Stockage</Text>
 
-          {/* Statistiques générales */}
           <View style={styles.card}>
             <View style={styles.cardHeader}>
               <Database size={20} color="#667EEA" />
@@ -332,7 +152,7 @@ export default function StorageDiagnostic() {
             </View>
             <View style={styles.statRow}>
               <Text style={styles.statLabel}>Synchronisation:</Text>
-              <Text style={[styles.statValue, { color: stats?.syncEnabled ? '#10B981' : '#EF4444' }]}>
+              <Text style={[styles.statValue, { color: stats?.syncEnabled ? '#10B981' : '#EF4444' }]}> 
                 {stats?.syncEnabled ? 'Activée' : 'Désactivée'}
               </Text>
             </View>
@@ -342,13 +162,12 @@ export default function StorageDiagnostic() {
             </View>
             <View style={styles.statRow}>
               <Text style={styles.statLabel}>Erreurs:</Text>
-              <Text style={[styles.statValue, { color: (stats?.errorCount || 0) > 0 ? '#EF4444' : '#10B981' }]}>
+              <Text style={[styles.statValue, { color: (stats?.errorCount || 0) > 0 ? '#EF4444' : '#10B981' }]}> 
                 {stats?.errorCount || 0}
               </Text>
             </View>
           </View>
 
-          {/* Diagnostic système */}
           <View style={styles.card}>
             <View style={styles.cardHeader}>
               <Cloud size={20} color="#667EEA" />
@@ -359,32 +178,11 @@ export default function StorageDiagnostic() {
               <Text style={styles.diagnosticLabel}>Utilisateur connecté</Text>
             </View>
             <View style={styles.diagnosticRow}>
-              {getStatusIcon(diagnostic?.encryptionKeyInitialized || false)}
-              <Text style={styles.diagnosticLabel}>Clé de chiffrement</Text>
-            </View>
-            <View style={styles.diagnosticRow}>
               {getStatusIcon(diagnostic?.cloudConnectivity || false)}
-              <Text style={styles.diagnosticLabel}>Connectivité cloud</Text>
-            </View>
-            <View style={styles.diagnosticRow}>
-              <Shield size={16} color={diagnostic?.circuitBreakerStatus?.includes('🚨') ? '#EF4444' : '#10B981'} />
-              <Text style={styles.diagnosticLabel}>Circuit Breaker: {diagnostic?.circuitBreakerStatus}</Text>
-            </View>
-            <View style={styles.diagnosticRow}>
-              {getStatusIcon((diagnostic?.corruptedDocs.length || 0) === 0)}
-              <Text style={styles.diagnosticLabel}>
-                Documents corrompus: {diagnostic?.corruptedDocs.length || 0}
-              </Text>
-            </View>
-            <View style={styles.diagnosticRow}>
-              {getStatusIcon((diagnostic?.ignoredDocs.length || 0) === 0)}
-              <Text style={styles.diagnosticLabel}>
-                Documents ignorés: {diagnostic?.ignoredDocs.length || 0}
-              </Text>
+              <Text style={styles.diagnosticLabel}>Connectivité PostgreSQL</Text>
             </View>
           </View>
 
-          {/* Actions */}
           <View style={styles.actionsContainer}>
             <TouchableOpacity
               style={[styles.actionButton, actionInProgress === 'sync' && styles.actionButtonDisabled]}
@@ -394,17 +192,6 @@ export default function StorageDiagnostic() {
               <RefreshCw size={16} color="#FFF" />
               <Text style={styles.actionButtonText}>
                 {actionInProgress === 'sync' ? 'Synchronisation...' : 'Forcer la Sync'}
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[styles.actionButton, styles.warningButton, actionInProgress === 'cleanup' && styles.actionButtonDisabled]}
-              onPress={handleCleanupCorrupted}
-              disabled={actionInProgress !== null || !user}
-            >
-              <Trash2 size={16} color="#FFF" />
-              <Text style={styles.actionButtonText}>
-                {actionInProgress === 'cleanup' ? 'Nettoyage...' : 'Nettoyer Documents'}
               </Text>
             </TouchableOpacity>
 
@@ -426,52 +213,6 @@ export default function StorageDiagnostic() {
             >
               <RefreshCw size={16} color="#667EEA" />
               <Text style={[styles.actionButtonText, { color: '#667EEA' }]}>Actualiser</Text>
-            </TouchableOpacity>
-
-            {/* Reset Circuit Breaker */}
-            <TouchableOpacity
-              style={[styles.actionButton, styles.warningButton, actionInProgress === 'circuit-reset' && styles.actionButtonDisabled]}
-              onPress={handleResetCircuitBreaker}
-              disabled={actionInProgress !== null}
-            >
-              <Shield size={16} color="#FFF" />
-              <Text style={styles.actionButtonText}>
-                {actionInProgress === 'circuit-reset' ? 'Reset...' : 'Reset Circuit Breaker'}
-              </Text>
-            </TouchableOpacity>
-
-            {/* Nouveaux boutons de diagnostic */}
-            <TouchableOpacity
-              style={[styles.actionButton, actionInProgress === 'diagnostic' && styles.actionButtonDisabled]}
-              onPress={handleRunFullDiagnostic}
-              disabled={actionInProgress !== null}
-            >
-              <AlertTriangle size={16} color="#FFF" />
-              <Text style={styles.actionButtonText}>
-                {actionInProgress === 'diagnostic' ? 'Diagnostic...' : 'Diagnostic Complet'}
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[styles.actionButton, styles.warningButton, actionInProgress === 'force-sync-local' && styles.actionButtonDisabled]}
-              onPress={handleForceSyncLocal}
-              disabled={actionInProgress !== null || !user}
-            >
-              <RefreshCw size={16} color="#FFF" />
-              <Text style={styles.actionButtonText}>
-                {actionInProgress === 'force-sync-local' ? 'Sync Local...' : 'Force Sync Local→Cloud'}
-              </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[styles.actionButton, styles.warningButton, actionInProgress === 'unblock' && styles.actionButtonDisabled]}
-              onPress={handleUnblockUploads}
-              disabled={actionInProgress !== null || !user}
-            >
-              <Upload size={16} color="#FFF" />
-              <Text style={styles.actionButtonText}>
-                {actionInProgress === 'unblock' ? 'Déblocage...' : 'Débloquer Uploads'}
-              </Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -521,71 +262,65 @@ const styles = StyleSheet.create({
   cardHeader: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 16,
+    marginBottom: 12,
   },
   cardTitle: {
     fontSize: 18,
     fontWeight: '600',
-    color: '#1F2937',
+    color: '#333',
     marginLeft: 8,
   },
   statRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
+    marginBottom: 6,
   },
   statLabel: {
     fontSize: 14,
-    color: '#6B7280',
+    color: '#666',
   },
   statValue: {
     fontSize: 14,
-    fontWeight: '600',
-    color: '#1F2937',
+    color: '#333',
+    fontWeight: '500',
   },
   diagnosticRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: 8,
+    marginBottom: 8,
   },
   diagnosticLabel: {
     fontSize: 14,
-    color: '#1F2937',
-    marginLeft: 12,
+    color: '#333',
+    marginLeft: 8,
   },
   actionsContainer: {
-    marginTop: 20,
+    marginTop: 4,
   },
   actionButton: {
-    backgroundColor: '#667EEA',
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 16,
-    borderRadius: 12,
-    marginBottom: 12,
+    backgroundColor: '#667EEA',
+    paddingVertical: 12,
+    borderRadius: 10,
+    marginBottom: 10,
   },
   actionButtonDisabled: {
     opacity: 0.6,
   },
-  warningButton: {
-    backgroundColor: '#F59E0B',
+  actionButtonText: {
+    color: '#FFF',
+    fontSize: 15,
+    fontWeight: '600',
+    marginLeft: 8,
   },
   dangerButton: {
     backgroundColor: '#EF4444',
   },
   secondaryButton: {
-    backgroundColor: 'transparent',
-    borderWidth: 2,
+    backgroundColor: '#FFF',
+    borderWidth: 1,
     borderColor: '#667EEA',
-  },
-  actionButtonText: {
-    color: '#FFF',
-    fontSize: 16,
-    fontWeight: '600',
-    marginLeft: 8,
   },
 });

--- a/hooks/useCloudSync.ts
+++ b/hooks/useCloudSync.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { SecureHybridStorage } from '@/utils/secureCloudStorage';
+import { getCloudStorageProvider } from '@/utils/cloudStorageProvider';
 
 /**
  * Hook pour initialiser automatiquement la synchronisation cloud
@@ -10,26 +10,15 @@ export function useCloudSync() {
   const { user } = useAuth();
 
   useEffect(() => {
+    const { hybrid } = getCloudStorageProvider();
+
     if (user) {
-      // Utilisateur connecté : initialiser la synchronisation cloud
-      SecureHybridStorage.initialize().catch(console.error);
-      
-      // Activer la synchronisation si elle n'est pas déjà activée
-      SecureHybridStorage.setSyncEnabled(true).catch(console.error);
+      hybrid.initialize().catch(console.error);
+      hybrid.setSyncEnabled(true).catch(console.error);
 
-  // Démarrer les écouteurs automatiques et l'abonnement temps réel
-  SecureHybridStorage.startAutoSyncListeners().catch(console.error);
-  SecureHybridStorage.startRealtimeSubscription().catch(console.error);
-      
-      console.log('Synchronisation cloud initialisée pour:', user.email);
+      console.log('Synchronisation cloud PostgreSQL initialisée pour:', user.email);
     } else {
-      // Utilisateur déconnecté : désactiver la synchronisation cloud
-      SecureHybridStorage.setSyncEnabled(false).catch(console.error);
-
-  // Arrêter les écouteurs et l'abonnement
-  SecureHybridStorage.stopRealtimeSubscription().catch(console.error);
-  SecureHybridStorage.stopAutoSyncListeners().catch(console.error);
-      
+      hybrid.setSyncEnabled(false).catch(console.error);
       console.log('Synchronisation cloud désactivée');
     }
   }, [user]);

--- a/utils/cloudStorageProvider.ts
+++ b/utils/cloudStorageProvider.ts
@@ -1,26 +1,17 @@
-import { SecureCloudStorage, SecureHybridStorage } from '@/utils/secureCloudStorage';
 import { PostgresCloudStorage, PostgresHybridStorage } from '@/utils/postgresCloudStorage';
 import { getSyncProvider, SyncProvider } from '@/utils/syncProvider';
 
 export type CloudStorageProvider = {
   provider: SyncProvider;
-  hybrid: typeof SecureHybridStorage | typeof PostgresHybridStorage;
-  cloud: typeof SecureCloudStorage | typeof PostgresCloudStorage;
+  hybrid: typeof PostgresHybridStorage;
+  cloud: typeof PostgresCloudStorage;
 };
 
 export const getCloudStorageProvider = (): CloudStorageProvider => {
   const provider = getSyncProvider();
-  if (provider === 'postgres') {
-    return {
-      provider,
-      hybrid: PostgresHybridStorage,
-      cloud: PostgresCloudStorage,
-    };
-  }
-
   return {
     provider,
-    hybrid: SecureHybridStorage,
-    cloud: SecureCloudStorage,
+    hybrid: PostgresHybridStorage,
+    cloud: PostgresCloudStorage,
   };
 };

--- a/utils/initServices.ts
+++ b/utils/initServices.ts
@@ -1,12 +1,7 @@
-import { Platform } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Sentry from 'sentry-expo';
 import { getApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
-import { getStorage } from 'firebase/storage';
 import 'react-native-get-random-values';
-import * as Random from 'expo-random';
 import 'react-native-url-polyfill';
 
 /**
@@ -16,12 +11,12 @@ import 'react-native-url-polyfill';
 export const initializeServices = async () => {
   // Firebase est déjà initialisé dans ../config/firebase.ts
   // On utilise simplement les instances existantes
-  
+
   // Tester les polyfills pour crypto
   try {
     console.log('✅ react-native-get-random-values initialisé');
     console.log('✅ URL polyfills initialisés');
-    
+
     // Vérifier que crypto.getRandomValues fonctionne
     const testArray = new Uint8Array(10);
     crypto.getRandomValues(testArray);
@@ -31,12 +26,12 @@ export const initializeServices = async () => {
     console.error('❌ Erreur lors de l\'initialisation des polyfills crypto:', error);
     throw error;
   }
-  
+
   // Initialiser Sentry pour la gestion des erreurs
   try {
     // Utiliser un DSN valide pour activer Sentry
     const sentryDsn = process.env.EXPO_PUBLIC_SENTRY_DSN || 'YOUR_SENTRY_DSN_HERE';
-    
+
     if (sentryDsn && sentryDsn !== 'YOUR_SENTRY_DSN_HERE') {
       Sentry.init({
         dsn: sentryDsn,
@@ -57,7 +52,5 @@ export const initializeServices = async () => {
   return {
     firebase: getApp(),
     auth: getAuth(),
-    firestore: getFirestore(),
-    storage: getStorage(),
   };
 };

--- a/utils/storageManager.ts
+++ b/utils/storageManager.ts
@@ -8,11 +8,11 @@ import { auth } from '@/config/firebase';
 import { getCloudStorageProvider } from './cloudStorageProvider';
 import { GlucoseMeasurement, generateMeasurementId } from './storage';
 
-// Configuration du stockage (utilise les mêmes clés que SecureHybridStorage)
+// Configuration du stockage (utilise les mêmes clés que le stockage cloud)
 const STORAGE_CONFIG = {
   LOCAL_KEY: 'glucose_measurements', // Utiliser la même clé que storage.ts
-  SYNC_ENABLED_KEY: 'secure_cloud_sync_enabled', // Même clé que SecureHybridStorage
-  LAST_SYNC_KEY: 'last_secure_cloud_sync', // Même clé que SecureHybridStorage
+  SYNC_ENABLED_KEY: 'secure_cloud_sync_enabled', // Même clé que le stockage cloud
+  LAST_SYNC_KEY: 'last_secure_cloud_sync', // Même clé que le stockage cloud
   ERROR_LOG_KEY: 'storage_manager_error_log'
 };
 
@@ -61,7 +61,7 @@ export class StorageManager {
   static async addMeasurement(measurement: Omit<GlucoseMeasurement, 'id'>): Promise<GlucoseMeasurement> {
     try {
       const { hybrid } = getCloudStorageProvider();
-      // Si sync activé et utilisateur connecté, utiliser directement SecureHybridStorage
+      // Si sync activé et utilisateur connecté, utiliser directement le stockage cloud
       if (this.syncEnabled && auth.currentUser) {
         try {
           const savedMeasurement = await hybrid.addMeasurement(measurement);

--- a/utils/syncProvider.ts
+++ b/utils/syncProvider.ts
@@ -1,7 +1,5 @@
-export type SyncProvider = 'firebase' | 'postgres';
+export type SyncProvider = 'postgres';
 
-export const getSyncProvider = (): SyncProvider => {
-  return process.env.EXPO_PUBLIC_SYNC_PROVIDER === 'postgres' ? 'postgres' : 'firebase';
-};
+export const getSyncProvider = (): SyncProvider => 'postgres';
 
-export const isPostgresProvider = (): boolean => getSyncProvider() === 'postgres';
+export const isPostgresProvider = (): boolean => true;


### PR DESCRIPTION
### Motivation
- Consolidate cloud persistence to PostgreSQL and remove Firestore/Firebase storage paths while keeping Firebase Auth for authentication.

### Description
- Force the sync provider to PostgreSQL by changing `utils/syncProvider.ts` to return `'postgres'` and making `isPostgresProvider()` always true.
- Route all cloud storage to the PostgreSQL implementations by updating `utils/cloudStorageProvider.ts` and delegating hybrid operations to `PostgresHybridStorage`/`PostgresCloudStorage` only.
- Simplify UX and code paths that previously depended on Firestore by pruning Firebase-specific features in `app/(tabs)/syncSettings.tsx`, `components/StorageDiagnostic.tsx`, `hooks/useCloudSync.ts`, and `utils/hybridStorage.ts` to use the PostgreSQL hybrid flow.
- Remove unused Firebase service exports from `utils/initServices.ts` (no `firestore`/`storage` returned) and update `utils/storageManager.ts` comments to reflect the PostgreSQL/cloud rename.
- Update documentation (`README.md`, `FIREBASE_SETUP.md`, `GUIDE_FIREBASE.md`) to clarify that Firebase is retained for Auth only and that PostgreSQL is used for persistence, marking Firestore steps as optional for compatibility.

### Testing
- Attempted to start the dev server with `npm run dev -- --web`, which failed in this environment due to an Expo CLI `fetch` error; no further automated test suite was executed.
- No unit test or lint runs were performed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0fb8ebd88332b0c2523ac388149c)