### PR TITLE
Fix Expo dev script for Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "@types/node": "^24.3.0",
         "@types/react": "~19.0.10",
         "@types/react-native": "^0.72.8",
+        "cross-env": "^7.0.3",
         "ts-node": "^10.9.2",
         "typescript": "~5.8.3"
       }
@@ -7720,6 +7721,25 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "EXPO_NO_TELEMETRY=1 expo start",
+    "dev": "cross-env EXPO_NO_TELEMETRY=1 npx expo start",
     "build:web": "expo export --platform web",
     "lint": "expo lint",
     "server:dev": "node server/index.js"
@@ -87,6 +87,7 @@
     "@types/node": "^24.3.0",
     "@types/react": "~19.0.10",
     "@types/react-native": "^0.72.8",
+    "cross-env": "^7.0.3",
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3"
   }


### PR DESCRIPTION
### Motivation
- The existing `dev` script (`EXPO_NO_TELEMETRY=1 expo start`) fails on Windows shells because the POSIX-style env assignment and assumption of a globally installed `expo` binary cause `expo`/env not recognized errors. This change makes the script portable on Windows and Unix.

### Description
- Update `scripts.dev` in `package.json` to `cross-env EXPO_NO_TELEMETRY=1 npx expo start` and add `cross-env` to `devDependencies`, with corresponding `package-lock.json` updates.

### Testing
- Ran `npm install` to install the new dev dependency and update `package-lock.json`, which completed successfully; no automated test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e372ac03c8332ad08a1681e3161ea)