### PR TITLE
Étendre la documentation : configuration Neon PostgreSQL

### DIFF
--- a/docs/neon-postgresql.md
+++ b/docs/neon-postgresql.md
@@ -5,19 +5,42 @@ GlycoFlex utilise uniquement PostgreSQL pour la persistance en ligne. La base es
 ## 1. Créer le projet Neon
 
 1. Ouvrez [neon.com](https://neon.com) et créez un projet.
-2. Récupérez l'URL de connexion PostgreSQL (format `postgres://...`).
+2. Dans le tableau de bord Neon, ouvrez l'onglet **Connection details** ou **Connection string**.
+3. Copiez la chaîne au format `postgres://...` (ou `postgresql://...`) pour la branche par défaut.
+   - Elle contient déjà l'hôte, le port, l'utilisateur et le nom de la base.
+   - Si Neon propose un paramètre SSL (`sslmode=require`), conservez-le : il est requis par défaut.
+4. Gardez cette URL pour la variable `NEON_DATABASE_URL` (elle sert à la fois à l'initialisation du schéma et à l'API).
 
 ## 2. Initialiser le schéma
 
-Exécutez le script `server/schema.sql` dans Neon pour créer les tables `users`, `user_sessions` et `glucose_measurements` :
+Exécutez le script `server/schema.sql` dans Neon pour créer les tables `users`, `user_sessions` et `glucose_measurements`.
+
+### Option A — en ligne de commande (psql)
+
+1. Installez `psql` si besoin (PostgreSQL client).
+2. Exportez la variable avec l'URL copiée depuis Neon.
+3. Lancez le script :
 
 ```bash
+export NEON_DATABASE_URL="postgres://user:password@hostname/dbname?sslmode=require"
 psql "$NEON_DATABASE_URL" -f server/schema.sql
 ```
 
+### Option B — via la console SQL Neon
+
+1. Dans Neon, ouvrez **SQL Editor**.
+2. Ouvrez `server/schema.sql` et copiez son contenu.
+3. Collez-le dans l'éditeur Neon puis exécutez.
+
 ## 3. Configurer l'API de synchronisation
 
-Créez un fichier `.env` dans le dossier `server/` (ou configurez vos variables d'environnement) :
+Créez un fichier `.env` dans le dossier `server/` (ou configurez vos variables d'environnement).
+Voici comment obtenir chaque valeur :
+
+- **NEON_DATABASE_URL** : l'URL PostgreSQL copiée dans Neon (étape 1).
+- **PORT** : le port d'écoute local de l'API (3001 par défaut).
+- **CORS_ORIGIN** : l'URL de votre application mobile ou web autorisée à appeler l'API.
+  - En développement Expo, utilisez par exemple `http://localhost:8081` ou l'URL du tunnel si vous utilisez `expo start --tunnel`.
 
 ```bash
 NEON_DATABASE_URL=postgres://user:password@hostname/dbname
@@ -33,7 +56,11 @@ npm run server:dev
 
 ## 4. Configurer l'application Expo
 
-Ajoutez l'URL de l'API dans le `.env` côté mobile :
+Ajoutez l'URL de l'API dans le `.env` côté mobile.
+Cette URL doit pointer vers le serveur Node.js (étape 3), par exemple :
+
+- **En local** : `http://localhost:3001`
+- **En staging/production** : `https://api.votre-domaine.com`
 
 ```bash
 EXPO_PUBLIC_SYNC_API_URL=https://votre-api.exemple.com


### PR DESCRIPTION
### Motivation

- Clarifier comment récupérer et utiliser l'URL de connexion Neon, y compris la valeur SSL (`sslmode=require`).
- Expliquer les différentes façons d'initialiser le schéma de la base (`psql` ou l'éditeur SQL Neon).
- Rendre explicite la configuration des variables d'environnement et l'URL de l'API côté serveur et Expo.

### Description

- Mise à jour de `docs/neon-postgresql.md` pour indiquer où trouver les `Connection details` dans le tableau de bord Neon et rappeler les formats `postgres://` / `postgresql://` ainsi que la présence possible de `sslmode=require`.
- Ajout d'une option A détaillée pour initialiser le schéma en local avec `psql`, incluant l'exemple `export NEON_DATABASE_URL="postgres://user:password@hostname/dbname?sslmode=require"` et la commande `psql "$NEON_DATABASE_URL" -f server/schema.sql`.
- Ajout d'une option B pour exécuter le SQL via la console `SQL Editor` de Neon en copiant le contenu de `server/schema.sql`.
- Clarification des valeurs à fournir dans le fichier `.env` du serveur (`NEON_DATABASE_URL`, `PORT`, `CORS_ORIGIN`) et exemples d'URL d'API pour `EXPO_PUBLIC_SYNC_API_URL` en local et production.

### Testing

- Changement uniquement documentaire; aucun test automatisé n'a été modifié ni exécuté.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e45e394588332be8a926c897c3a9e)