### PR TITLE
Add `tslib` dependency for Sentry builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,8 @@
         "react-native-web": "^0.20.0",
         "react-native-webview": "13.13.5",
         "sentry-expo": "^7.2.0",
-        "sharp": "^0.34.3"
+        "sharp": "^0.34.3",
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -14666,8 +14667,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5",
     "sentry-expo": "^7.2.0",
-    "sharp": "^0.34.3"
+    "sharp": "^0.34.3",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
### Motivation
- Metro bundling failed because `@sentry/react-native` imports `tslib` but the project did not declare it, causing Android bundle errors during build.

### Description
- Add `tslib` to `dependencies` in `package.json` to satisfy the `@sentry/react-native` import.
- Update `package-lock.json` with the installed `tslib` entry (`tslib@2.8.1`).
- Installed the dependency locally with `npm install tslib@^2.6.3` and committed the updated `package.json` and `package-lock.json`.

### Testing
- No automated tests were run for this dependency-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e7f665d1c8332ba803ac14b851fb4)