### PR TITLE
Remove hardcoded Sentry auth token from app config

### DIFF
--- a/app.json
+++ b/app.json
@@ -66,8 +66,7 @@
           "file": "sentry-expo/upload-sourcemaps",
           "config": {
             "organization": "your-sentry-organization",
-            "project": "glycoflex",
-            "authToken": "YOUR_AUTH_TOKEN_HERE"
+            "project": "glycoflex"
           }
         }
       ]


### PR DESCRIPTION
### Motivation
- Prevent committing a Sentry `authToken` in source and rely on the `SENTRY_AUTH_TOKEN` environment variable to follow security best practices and silence Expo warnings.

### Description
- Removed the `authToken` field from the `postPublish` hook configuration for `sentry-expo/upload-sourcemaps` in `app.json` so the build uses the `SENTRY_AUTH_TOKEN` environment variable instead.

### Testing
- No automated tests were run because this is a config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e813548008332be8ea320ccf38185)