### PR TITLE
Add Metro resolver mapping for tslib

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const { getDefaultConfig } = require('@expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.extraNodeModules = {
+  ...(config.resolver.extraNodeModules || {}),
+  tslib: path.resolve(__dirname, 'node_modules/tslib'),
+};
+
+module.exports = config;


### PR DESCRIPTION
### Motivation
- Fix Metro bundler error where `tslib` could not be resolved (seen when importing `@sentry/react-native` via `sentry-expo`) by ensuring Metro resolves `tslib` from the project root `node_modules`.

### Description
- Add `metro.config.js` which uses `getDefaultConfig(__dirname)` and sets `resolver.extraNodeModules` to map `tslib` to `path.resolve(__dirname, 'node_modules/tslib')` so Metro can locate the package.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e82dcdec88332926d4c3413ad6295)