### PR TITLE
Handle missing sync API config in auth

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -37,6 +37,11 @@ export default function AuthScreen() {
   };
 
   const handleLogin = async () => {
+    if (!auth.isAvailable) {
+      toast.show(t('auth.error'), t('auth.syncUnavailable'));
+      return;
+    }
+
     if (!validateEmail(email)) {
       toast.show(t('auth.error'), t('auth.invalidEmail'));
       return;
@@ -56,7 +61,9 @@ export default function AuthScreen() {
       console.error('Erreur de connexion:', error);
       let errorMessage = t('auth.loginError');
       const message = error?.message || '';
-      if (message.includes('not-found') || message.includes('not found')) {
+      if (message.includes('SYNC_API_URL_MISSING')) {
+        errorMessage = t('auth.syncUnavailable');
+      } else if (message.includes('not-found') || message.includes('not found')) {
         errorMessage = t('auth.userNotFound');
       } else if (message.includes('invalid-password') || message.includes('wrong-password') || message.includes('invalid password')) {
         errorMessage = t('auth.wrongPassword');
@@ -75,6 +82,11 @@ export default function AuthScreen() {
   };
 
   const handleRegister = async () => {
+    if (!auth.isAvailable) {
+      toast.show(t('auth.error'), t('auth.syncUnavailable'));
+      return;
+    }
+
     if (!validateEmail(email)) {
       toast.show(t('auth.error'), t('auth.invalidEmail'));
       return;
@@ -99,7 +111,9 @@ export default function AuthScreen() {
       console.error('Erreur de création de compte:', error);
       let errorMessage = t('auth.registerError');
       const message = error?.message || '';
-      if (message.includes('already') || message.includes('exists')) {
+      if (message.includes('SYNC_API_URL_MISSING')) {
+        errorMessage = t('auth.syncUnavailable');
+      } else if (message.includes('already') || message.includes('exists')) {
         errorMessage = t('auth.emailAlreadyInUse');
       } else if (message.includes('invalid-email')) {
         errorMessage = t('auth.invalidEmail');
@@ -116,6 +130,11 @@ export default function AuthScreen() {
   };
 
   const handlePasswordReset = async () => {
+    if (!auth.isAvailable) {
+      toast.show(t('auth.error'), t('auth.syncUnavailable'));
+      return;
+    }
+
     if (!validateEmail(email)) {
       toast.show(t('auth.error'), t('auth.invalidEmail'));
       return;

--- a/locales/en.json
+++ b/locales/en.json
@@ -333,7 +333,8 @@
     "wrongPassword": "Incorrect password",
     "userDisabled": "This account has been disabled",
     "emailAlreadyInUse": "This email address is already in use",
-    "weakPassword": "Password is too weak"
+    "weakPassword": "Password is too weak",
+    "syncUnavailable": "Cloud sync is not configured on this build"
   },
   "profile": {
     "title": "Profile",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -333,7 +333,8 @@
     "wrongPassword": "Mot de passe incorrect",
     "userDisabled": "Ce compte a été désactivé",
     "emailAlreadyInUse": "Cette adresse email est déjà utilisée",
-    "weakPassword": "Le mot de passe est trop faible"
+    "weakPassword": "Le mot de passe est trop faible",
+    "syncUnavailable": "La synchronisation cloud n'est pas configurée sur cette version"
   },
   "profile": {
     "title": "Profil",

--- a/utils/internalAuth.ts
+++ b/utils/internalAuth.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const AUTH_STORAGE_KEY = 'internal_auth_session';
-const API_BASE_URL = process.env.EXPO_PUBLIC_SYNC_API_URL;
+const API_BASE_URL = process.env.EXPO_PUBLIC_SYNC_API_URL?.trim();
 const SESSION_DURATION_DAYS = 30;
 
 export interface InternalUser {
@@ -35,7 +35,7 @@ const listeners = new Set<(user: InternalUser | null) => void>();
 
 const ensureApiUrl = () => {
   if (!API_BASE_URL) {
-    throw new Error('Missing EXPO_PUBLIC_SYNC_API_URL for internal auth');
+    throw new Error('SYNC_API_URL_MISSING');
   }
 };
 
@@ -120,6 +120,9 @@ const request = async <T>(path: string, options: RequestInit = {}): Promise<T> =
 };
 
 export const auth = {
+  get isAvailable() {
+    return Boolean(API_BASE_URL);
+  },
   get currentUser() {
     return currentUser ? { ...currentUser, uid: currentUser.id } : null;
   },


### PR DESCRIPTION
### Motivation
- Les logs montraient une erreur non gérée `Missing EXPO_PUBLIC_SYNC_API_URL for internal auth` qui bloquait les flux d'authentification lorsque la variable d'environnement de synchronisation était absente, provoquant des erreurs côté utilisateur et crashs visibles dans la console.

### Description
- Normalise et nettoie la variable `EXPO_PUBLIC_SYNC_API_URL` avec `?.trim()` et remplace le message d'erreur brut par un code explicite `SYNC_API_URL_MISSING` dans `utils/internalAuth.ts`.
- Expose un indicateur `auth.isAvailable` pour détecter si l'API de synchronisation est configurée dans `utils/internalAuth.ts`.
- Protège les flux UI d'authentification en refusant les actions `login`, `register` et `requestPasswordReset` quand `auth.isAvailable` est faux, avec gestion d'erreur utilisateur dans `app/auth.tsx` (affichage d'un message localisé au lieu d'une erreur brute).
- Ajoute les libellés localisés `syncUnavailable` dans `locales/en.json` et `locales/fr.json` pour informer l'utilisateur que la synchronisation cloud n'est pas configurée.

### Testing
- Aucun test automatisé n'a été exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e91d8ea808332971d2718254ab0f3)