### PR TITLE
Load environment before initializing database connection

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,12 +1,13 @@
 const path = require('path');
 const dotenv = require('dotenv');
+
+dotenv.config({ path: path.join(__dirname, '.env') });
+
 const express = require('express');
 const cors = require('cors');
 const { sql } = require('./db');
 const { authenticate, createSession, hashPassword, verifyPassword } = require('./auth');
 const { nanoid } = require('nanoid');
-
-dotenv.config({ path: path.join(__dirname, '.env') });
 
 const app = express();
 


### PR DESCRIPTION
### Motivation
- Ensure `NEON_DATABASE_URL` and other env vars are loaded before the DB client in `server/db.js` is initialized to prevent startup errors.

### Description
- Call `dotenv.config({ path: path.join(__dirname, '.env') })` at the top of `server/index.js` so environment variables are available before requiring `./db`; this updates `server/index.js`.

### Testing
- No automated tests were run for this change; this is an ordering fix to avoid a runtime error when `NEON_DATABASE_URL` is missing at import time.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980cd1468608332ab13a565d4605464)