### PR TITLE
Handle auth network errors gracefully

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -63,6 +63,8 @@ export default function AuthScreen() {
       const message = error?.message || '';
       if (message.includes('SYNC_API_URL_MISSING')) {
         errorMessage = t('auth.syncUnavailable');
+      } else if (message.includes('NETWORK_REQUEST_FAILED')) {
+        errorMessage = t('auth.networkError');
       } else if (message.includes('not-found') || message.includes('not found')) {
         errorMessage = t('auth.userNotFound');
       } else if (message.includes('invalid-password') || message.includes('wrong-password') || message.includes('invalid password')) {
@@ -113,6 +115,8 @@ export default function AuthScreen() {
       const message = error?.message || '';
       if (message.includes('SYNC_API_URL_MISSING')) {
         errorMessage = t('auth.syncUnavailable');
+      } else if (message.includes('NETWORK_REQUEST_FAILED')) {
+        errorMessage = t('auth.networkError');
       } else if (message.includes('already') || message.includes('exists')) {
         errorMessage = t('auth.emailAlreadyInUse');
       } else if (message.includes('invalid-email')) {
@@ -147,7 +151,11 @@ export default function AuthScreen() {
       setMode('login');
     } catch (error: any) {
       console.error('Erreur de réinitialisation:', error);
-      toast.show(t('auth.error'), t('auth.passwordResetError'));
+      const message = error?.message || '';
+      const errorMessage = message.includes('NETWORK_REQUEST_FAILED')
+        ? t('auth.networkError')
+        : t('auth.passwordResetError');
+      toast.show(t('auth.error'), errorMessage);
     } finally {
       setLoading(false);
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -334,7 +334,8 @@
     "userDisabled": "This account has been disabled",
     "emailAlreadyInUse": "This email address is already in use",
     "weakPassword": "Password is too weak",
-    "syncUnavailable": "Cloud sync is not configured on this build"
+    "syncUnavailable": "Cloud sync is not configured on this build",
+    "networkError": "Unable to reach the server. Check your connection."
   },
   "profile": {
     "title": "Profile",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -334,7 +334,8 @@
     "userDisabled": "Ce compte a été désactivé",
     "emailAlreadyInUse": "Cette adresse email est déjà utilisée",
     "weakPassword": "Le mot de passe est trop faible",
-    "syncUnavailable": "La synchronisation cloud n'est pas configurée sur cette version"
+    "syncUnavailable": "La synchronisation cloud n'est pas configurée sur cette version",
+    "networkError": "Impossible de joindre le serveur. Vérifiez votre connexion."
   },
   "profile": {
     "title": "Profil",

--- a/utils/internalAuth.ts
+++ b/utils/internalAuth.ts
@@ -102,10 +102,19 @@ const request = async <T>(path: string, options: RequestInit = {}): Promise<T> =
     ...(options.headers as Record<string, string> | undefined),
   };
 
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...options,
-    headers,
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE_URL}${path}`, {
+      ...options,
+      headers,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '';
+    if (message.includes('Network request failed')) {
+      throw new Error('NETWORK_REQUEST_FAILED');
+    }
+    throw error;
+  }
 
   if (!response.ok) {
     const message = await response.text();


### PR DESCRIPTION
### Motivation
- Distinguish network connectivity failures from API errors so the UI can show a helpful, localized message instead of a generic error. 
- Improve user experience for `login`, `register`, and `password reset` flows when fetch calls fail due to network issues.

### Description
- Normalize fetch failures in `utils/internalAuth.ts` by catching `fetch` exceptions and throwing a `NETWORK_REQUEST_FAILED` error when the underlying message contains `Network request failed`.
- Surface the new network error in the auth flows by checking for `NETWORK_REQUEST_FAILED` in `app/auth.tsx` and showing `t('auth.networkError')` for `login`, `register`, and password reset errors.
- Add localized copy for the new `auth.networkError` key in `locales/en.json` and `locales/fr.json`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698125acc9548332822aaf1bf33dc610)