### PR TITLE
Improve auth error messaging for localhost API

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -63,6 +63,8 @@ export default function AuthScreen() {
       const message = error?.message || '';
       if (message.includes('SYNC_API_URL_MISSING')) {
         errorMessage = t('auth.syncUnavailable');
+      } else if (message.includes('NETWORK_REQUEST_FAILED_LOCALHOST')) {
+        errorMessage = t('auth.networkErrorLocalhost');
       } else if (message.includes('NETWORK_REQUEST_FAILED')) {
         errorMessage = t('auth.networkError');
       } else if (message.includes('not-found') || message.includes('not found')) {
@@ -115,6 +117,8 @@ export default function AuthScreen() {
       const message = error?.message || '';
       if (message.includes('SYNC_API_URL_MISSING')) {
         errorMessage = t('auth.syncUnavailable');
+      } else if (message.includes('NETWORK_REQUEST_FAILED_LOCALHOST')) {
+        errorMessage = t('auth.networkErrorLocalhost');
       } else if (message.includes('NETWORK_REQUEST_FAILED')) {
         errorMessage = t('auth.networkError');
       } else if (message.includes('already') || message.includes('exists')) {

--- a/locales/en.json
+++ b/locales/en.json
@@ -335,7 +335,8 @@
     "emailAlreadyInUse": "This email address is already in use",
     "weakPassword": "Password is too weak",
     "syncUnavailable": "Cloud sync is not configured on this build",
-    "networkError": "Unable to reach the server. Check your connection."
+    "networkError": "Unable to reach the server. Check your connection.",
+    "networkErrorLocalhost": "Unable to reach the server from your device. Use your computer's IP address instead of localhost or deploy the API."
   },
   "profile": {
     "title": "Profile",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -335,7 +335,8 @@
     "emailAlreadyInUse": "Cette adresse email est déjà utilisée",
     "weakPassword": "Le mot de passe est trop faible",
     "syncUnavailable": "La synchronisation cloud n'est pas configurée sur cette version",
-    "networkError": "Impossible de joindre le serveur. Vérifiez votre connexion."
+    "networkError": "Impossible de joindre le serveur. Vérifiez votre connexion.",
+    "networkErrorLocalhost": "Impossible de joindre le serveur depuis le téléphone. Utilisez l'adresse IP de votre ordinateur plutôt que localhost ou déployez l'API."
   },
   "profile": {
     "title": "Profil",


### PR DESCRIPTION
### Motivation
- Mobile devices often cannot reach an API served at `localhost` on the development machine, which produces a generic network failure that confuses users and developers.
- Surface a distinct error for local API URLs so the app can show actionable guidance (use device IP or deploy the API) instead of a generic network error.

### Description
- Added hostname detection in `utils/internalAuth.ts` (`LOCAL_HOSTNAMES` and `isLocalApiUrl`) and throw a distinct error code `NETWORK_REQUEST_FAILED_LOCALHOST` when `fetch` fails against a localhost-style `EXPO_PUBLIC_SYNC_API_URL`.
- Mapped the new error code to a user-facing message in the authentication flows (`app/auth.tsx`) for both login and registration paths using the key `auth.networkErrorLocalhost`.
- Added localized copy for the new message in `locales/en.json` and `locales/fr.json` explaining that the device should use the computer IP or deploy the API.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69812a7a6134833296dc047fd68a8104)