### PR TITLE
Load server .env before importing db module

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,12 +1,13 @@
 const path = require('path');
 const dotenv = require('dotenv');
+
+dotenv.config({ path: path.join(__dirname, '.env') });
+
 const express = require('express');
 const cors = require('cors');
 const { sql } = require('./db');
 const { authenticate, createSession, hashPassword, verifyPassword } = require('./auth');
 const { nanoid } = require('nanoid');
-
-dotenv.config({ path: path.join(__dirname, '.env') });
 
 const app = express();
 


### PR DESCRIPTION
### Motivation
- Prevent startup crashes by ensuring `server/.env` is loaded before any module (notably `./db`) reads `process.env.NEON_DATABASE_URL` at require time.

### Description
- Moved `dotenv.config({ path: path.join(__dirname, '.env') })` to the top of `server/index.js` so the environment file is loaded before requiring `./db` and other modules that access env vars.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874ffdb5e08332ba3398fcdb135cad)